### PR TITLE
fix: correct stale log paths in claude-code project_instructions

### DIFF
--- a/product/ai-rules/claude-code/project_instructions.md
+++ b/product/ai-rules/claude-code/project_instructions.md
@@ -7,10 +7,10 @@ This project uses the **Log File Genius** system - a token-efficient documentati
 1. **Read Configuration First:**
    - **ALWAYS** read `.logfile-config.yml` to find log file locations
    - Default paths (if config not found):
-     - CHANGELOG: `docs/planning/CHANGELOG.md`
-     - DEVLOG: `docs/planning/DEVLOG.md`
-     - ADR: `docs/adr/`
-     - STATE: `docs/STATE.md`
+     - CHANGELOG: `logs/CHANGELOG.md`
+     - DEVLOG: `logs/DEVLOG.md`
+     - ADR: `logs/adr/`
+     - STATE: `logs/STATE.md`
 
 2. **Maintain the Five-Document System:**
    - **PRD** - What we're building and why
@@ -42,11 +42,11 @@ When the user invokes these commands, follow the corresponding rule file:
 
 - **Configuration:** `.logfile-config.yml` (log file paths)
 - **Full methodology:** `.log-file-genius/product/docs/log_file_how_to.md`
-- **Templates:** `log-file-genius/templates/` directory
-- **Validation:** `./log-file-genius/scripts/validate-log-files.sh`
+- **Templates:** `.log-file-genius/product/templates/` directory
+- **Validation:** `.log-file-genius/product/scripts/validate-log-files.sh`
 
 ## Important Notes
 
 - Always read `.logfile-config.yml` to find log file locations
-- Templates in `log-file-genius/templates/` are customizable
+- Templates in `.log-file-genius/product/templates/` are customizable
 - Check `.log-file-genius/product/docs/log_file_how_to.md` for detailed guidance


### PR DESCRIPTION
## Summary
The Claude Code `project_instructions.md` shipped paths that don't match what the installer actually creates.

- **Default log paths** listed `docs/planning/CHANGELOG.md`, `docs/planning/DEVLOG.md`, `docs/adr/`, `docs/STATE.md`. The installer (`install.sh` / `install.ps1`) creates the five-document system under `logs/`. Corrected the defaults to `logs/`.
- **Quick Reference paths** for Templates and Validation were missing the leading dot and the `product/` segment (`log-file-genius/templates/` -> `.log-file-genius/product/templates/`, `./log-file-genius/scripts/...` -> `.log-file-genius/product/scripts/...`).

## Why it matters
`.logfile-config.yml` normally carries the correct paths, so this is masked in a standard install. But the file explicitly documents fallback behavior "if config not found" — and in that path an agent gets sent to non-existent locations. The Templates/Validation references are simply broken as written regardless of config.

## Test plan
- [x] Confirmed `product/templates/` and `product/scripts/validate-log-files.sh` exist at the corrected paths
- [x] Confirmed installer copies templates to `logs/` (CHANGELOG/DEVLOG/STATE) and `logs/adr/TEMPLATE.md`
- [x] Maintainer: confirm `logs/` is the intended canonical default (vs. legacy `docs/planning/`)