### PR TITLE
Spec 4: brownfield-safe install & update (v0.4.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,36 @@ CI runs `lfg generate --check` on every PR and will fail if `AGENTS.md` is out
 of date relative to the fragments. To avoid forgetting, install the pre-commit
 hook below.
 
+#### AGENTS.md is emitted two ways
+
+The generator renders the fragment content through two entry points (both in
+`product/scripts/generator.py`):
+
+- **`render_full()`** writes the in-repo `product/AGENTS.md` — fully LFG-owned, **no
+  markers**. This is what `lfg generate` produces and what CI checks.
+- **`render_block()`** wraps the same canonical body in `<!-- LFG:BEGIN v… -->` /
+  `<!-- LFG:END -->` markers. This is the block that `install`/`update` (via
+  `lfg merge-agents-md`) merge into a *user's* `AGENTS.md`, leaving their surrounding
+  content intact.
+
+Both share a single `render_canonical_body()` primitive, so editing a fragment under
+`product/rules/` and running `lfg generate` keeps both outputs in sync. **The marker
+format is a documented part of the distributable's contract — don't change the marker
+strings or the `v<version>` token in the BEGIN marker without a deliberate version bump.**
+
+#### Regenerate template hashes when templates change
+
+If you add, remove, or modify any file under `product/templates/`, regenerate the shipped
+hash manifest:
+
+```bash
+python product/scripts/update_template_hashes.py
+```
+
+This updates `product/scripts/known_template_hashes.json`, which the updater uses to
+recognize (and safely back up) LFG-installed root `templates/` folders. CI gates that the
+manifest is current for the present version — a forgotten regen will fail the build.
+
 ### Optional: pre-commit auto-regenerate
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ The installer will:
 2. **Prompt for profile** - Choose from: solo-developer, team, open-source, or startup
 3. **Create folder structure** - Creates `logs/` and `logs/adr/`
 4. **Install templates** - Copies CHANGELOG, DEVLOG, STATE, and ADR templates to `logs/`
-5. **Install AGENTS.md** - Drops the canonical agent-agnostic rules at the project root
+5. **Install AGENTS.md** - Merges the canonical agent-agnostic rules into a marker-delimited block in your project-root `AGENTS.md` (creating it if absent; preserving any existing content)
 6. **Install per-tool rules** - Generates platform-specific rule files in `.augment/rules/` or `.claude/rules/`
 7. **Create config file** - Generates `.logfile-config.yml` with your profile settings
 8. **Validate installation** - Checks that all required files exist
@@ -67,6 +67,14 @@ All generated from the same canonical fragments in `product/rules/`:
 
 ### Hidden Source Repository
 - `.log-file-genius/` - Git submodule containing templates, scripts, and documentation (for updates)
+
+> **Templates live in the submodule** at `.log-file-genius/product/templates/`. The
+> installer does **not** create a `templates/` directory at your project root.
+
+> **AGENTS.md is merged, not overwritten.** If your project already has an `AGENTS.md`
+> (e.g., a Codex/Aider file), the installer inserts a marker-delimited LFG block
+> (`<!-- LFG:BEGIN … -->` … `<!-- LFG:END -->`) and preserves everything outside the
+> markers. The same merge runs on every update — your content is safe across upgrades.
 
 ---
 
@@ -196,8 +204,9 @@ ls -la logs/
 ## Updating Log File Genius
 
 To update to the latest version, use the bundled `update.sh` / `update.ps1`. The
-updater refreshes `AGENTS.md`, per-tool rules, validators, and the `lfg` CLI
-while preserving your customizations.
+update is **brownfield-safe**: it **merges** the LFG block into your `AGENTS.md`
+(content outside the markers is preserved — never overwritten), refreshes per-tool
+rules, validators, and the `lfg` CLI, and never creates a root `templates/` directory.
 
 ```bash
 # Bash/Mac/Linux
@@ -210,6 +219,19 @@ cd .log-file-genius && git pull && cd ..
 cd .log-file-genius; git pull; cd ..
 .\.log-file-genius\product\scripts\update.ps1
 ```
+
+**Upgrading from an older version?** After the update, you may see a one-line advisory:
+
+```
+STATE.md needs migration to v0.4.0 spec. Preview with: lfg migrate-state --dry-run
+```
+
+This is not an error — it means your STATE.md predates the current spec. Run
+`lfg migrate-state --dry-run` to preview a deterministic migration that keeps the
+canonical sections and archives any extra content into a one-time DEVLOG snapshot, then
+`lfg migrate-state` to apply it. It is one-shot (safe to ignore if STATE already
+conforms). If a prior version left an LFG-installed root `templates/` folder, the updater
+moves it into `.log-file-genius/.backups/`.
 
 ---
 
@@ -230,6 +252,8 @@ Key commands:
 - `lfg archive` — apply it (protects `[Unreleased]` and the most recent DEVLOG entries)
 - `lfg prime` — emit a compact digest for subagent initial context
 - `lfg promote <staged-id>` — merge a subagent's staged entries into CHANGELOG/DEVLOG
+- `lfg migrate-state --dry-run` — preview a one-time STATE.md migration to the current spec; apply with `lfg migrate-state`
+- `lfg merge-agents-md --to <path>` — merge the LFG block into a target `AGENTS.md`, preserving your content (normally run by install/update)
 - `lfg generate` — regenerate `AGENTS.md` from fragments (contributors only)
 
 Run `--help` on any subcommand for flags.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ cd .log-file-genius; git pull; cd ..
 .\.log-file-genius\product\scripts\update.ps1
 ```
 
-The updater preserves your customizations and refreshes `AGENTS.md`, per-tool rules, validators, and the `lfg` CLI in place.
+The updater is brownfield-safe: it **merges** the LFG rules into your `AGENTS.md` instead of overwriting it (anything outside the `<!-- LFG:BEGIN … -->` / `<!-- LFG:END -->` markers stays yours), refreshes per-tool rules, validators, and the `lfg` CLI in place, and never creates a `templates/` folder at your project root.
+
+Upgrading from an older version? If the updater prints a STATE.md advisory, run `python .log-file-genius/product/scripts/lfg.py migrate-state --dry-run` to preview the one-time migration. See [Updating Log File Genius](product/docs/log_file_how_to.md#updating-log-file-genius) for the full story.
 
 ---
 
@@ -191,6 +193,9 @@ After installation, a small Python CLI lives at `.log-file-genius/product/script
 | `lfg archive --dry-run` | Preview a graceful, work-aware archival plan |
 | `lfg archive` | Apply the plan (protects `[Unreleased]` and the most recent DEVLOG entries) |
 | `lfg generate` | Regenerate `AGENTS.md` from `product/rules/` fragments (contributors) |
+| `lfg merge-agents-md --to <path>` | Merge the LFG managed block into a target `AGENTS.md`, preserving your content (run by install/update) |
+| `lfg migrate-state --dry-run` | Preview bringing a pre-v0.4.0 STATE.md into the current spec |
+| `lfg migrate-state` | Apply the one-time STATE migration (archives extra content to a DEVLOG snapshot) |
 | `lfg prime` | Print a compact digest for a subagent's initial context |
 | `lfg promote <staged-id>` | Merge a subagent's staged log entries into CHANGELOG/DEVLOG |
 

--- a/product/VERSION.json
+++ b/product/VERSION.json
@@ -1,15 +1,15 @@
 {
-  "version": "0.3.0",
-  "release_date": "2026-05-29",
+  "version": "0.4.0",
+  "release_date": "2026-06-01",
   "components": {
-    "installer": "0.3.0",
-    "validator": "0.3.0",
-    "linter": "0.3.0",
-    "ai-rules": "0.3.0",
-    "templates": "0.3.0",
-    "profiles": "0.3.0",
-    "secrets": "0.3.0",
-    "cli": "0.3.0"
+    "installer": "0.4.0",
+    "validator": "0.4.0",
+    "linter": "0.4.0",
+    "ai-rules": "0.4.0",
+    "templates": "0.4.0",
+    "profiles": "0.4.0",
+    "secrets": "0.4.0",
+    "cli": "0.4.0"
   },
   "compatibility": {
     "min_python": "3.8",
@@ -17,10 +17,10 @@
     "min_bash": "4.0"
   },
   "checksums": {
-    "install.ps1": "20c049b8d30db7a6",
-    "install.sh": "0e95c61bb0868ffd",
-    "lint-logs.py": "4737f1b27a39c353",
-    "validate-log-files.ps1": "36c5d4b00834fd12",
-    "validate-log-files.sh": "d992005d7c260769"
+    "install.ps1": "aa1020ff63d76644",
+    "install.sh": "444415d6a3773c05",
+    "lint-logs.py": "6ec1b128ee08b1b9",
+    "validate-log-files.ps1": "47cbe9b9fe70e163",
+    "validate-log-files.sh": "0e84daca84bb530d"
   }
 }

--- a/product/docs/log_file_how_to.md
+++ b/product/docs/log_file_how_to.md
@@ -16,10 +16,11 @@
 6. [Entry Formats](#entry-formats)
 7. [Update Cadence](#update-cadence---when-to-update-each-document)
 8. [Maintenance Workflow](#maintenance-workflow)
-9. [Token Budget Management](#token-budget-management)
-10. [Problem/Solution Pairs](#problemsolution-pairs)
-11. [Examples Directory](#examples-directory)
-12. [Starter Templates](#starter-templates)
+9. [Updating Log File Genius](#updating-log-file-genius)
+10. [Token Budget Management](#token-budget-management)
+11. [Problem/Solution Pairs](#problemsolution-pairs)
+12. [Examples Directory](#examples-directory)
+13. [Starter Templates](#starter-templates)
 
 ---
 
@@ -486,7 +487,7 @@ project-root/
     └── check_token_counts.py    # Monitoring script
 ```
 
-> **Path resolution:** Agents look for `paths` in `.logfile-config.yml` first; if not present, `logs/` is the default. Templates live wherever your installer placed them.
+> **Path resolution:** Agents look for `paths` in `.logfile-config.yml` first; if not present, `logs/` is the default. Templates ship in the submodule at `.log-file-genius/product/templates/` (not copied to your project root).
 
 ### Document Relationships
 
@@ -991,6 +992,79 @@ The dry-run prints a plan: which version blocks (CHANGELOG) and which old entrie
 Each source file retains a `## Archive` section with one bullet per archive file (relative link + summary).
 
 **If `[Unreleased]` alone exceeds budget**, `lfg archive` refuses with exit 2 — you trim Unreleased manually. There is no `--force-include-unreleased` flag by design.
+
+---
+
+## Updating Log File Genius
+
+Updates are **brownfield-safe**: the updater never clobbers content you own. Pull the
+submodule and run the bundled updater:
+
+```bash
+cd .log-file-genius && git pull && cd ..
+./.log-file-genius/product/scripts/update.sh      # update.ps1 on Windows
+```
+
+### AGENTS.md is merged, not overwritten
+
+`AGENTS.md` (introduced in v0.3.0) is now maintained as a **marker-delimited managed
+block** inside whatever `AGENTS.md` lives at your project root. Install and update merge
+the LFG block; they no longer replace the file. The markers are HTML comments (invisible
+in rendered markdown):
+
+```
+<!-- LFG:BEGIN v0.4.0 — DO NOT EDIT BETWEEN THESE MARKERS -->
+...LFG-generated rules...
+<!-- LFG:END -->
+```
+
+- **Anything outside the markers is yours** and is preserved across updates.
+- **Do not edit between the markers** — that region is regenerated from `product/rules/`
+  on every update; your edits there would be overwritten.
+- If you already had a hand-authored `AGENTS.md` (e.g., a Codex/Aider file), the LFG block
+  is prepended above your content. If you had a prior LFG-generated `AGENTS.md` (no
+  markers — e.g. from v0.3.0), its body is regenerated; because there are no markers to
+  tell your additions apart from old LFG content, the original is **saved to
+  `AGENTS.md.bak` first** so anything you added can be recovered. After your first
+  update the file has markers, so later updates only touch the marked region.
+
+The merge runs automatically during install/update. You can also run it directly:
+
+```bash
+python .log-file-genius/product/scripts/lfg.py merge-agents-md --to AGENTS.md
+```
+
+It is idempotent — re-running on an up-to-date file writes nothing.
+
+### Migrating a pre-v0.4.0 STATE.md
+
+v0.3.0+ enforces a stricter STATE.md spec (canonical sections: Current Context, Active
+Work, Blockers, etc.). If you upgraded from an older project, the updater may print:
+
+```
+STATE.md needs migration to v0.4.0 spec. Preview with: lfg migrate-state --dry-run
+```
+
+`lfg migrate-state` brings STATE.md into compliance deterministically — it keeps the
+canonical sections and archives any extra content into a single one-time DEVLOG snapshot
+entry (`### YYYY-MM-DD: STATE snapshot pre-v0.4.0 migration`) so nothing is lost. Preview,
+then apply:
+
+```bash
+python .log-file-genius/product/scripts/lfg.py migrate-state --dry-run   # preview the plan
+python .log-file-genius/product/scripts/lfg.py migrate-state             # confirm + apply
+```
+
+It is **one-shot**: once STATE.md is compliant (or the DEVLOG snapshot already exists),
+re-running is a no-op. Use `--force` to skip the confirmation prompt in scripts.
+
+### Where templates live
+
+Templates ship in the submodule at `.log-file-genius/product/templates/` only — the
+updater no longer creates a `templates/` directory at your project root. If a prior LFG
+version left an LFG-installed root `templates/` behind, the updater moves it into
+`.log-file-genius/.backups/` (user-authored templates that don't match shipped versions
+are left untouched).
 
 ---
 

--- a/product/scripts/agents_merge.py
+++ b/product/scripts/agents_merge.py
@@ -1,0 +1,269 @@
+"""Managed-block AGENTS.md merge engine (Spec 4 §1).
+
+The P0 data-safety core: lets LFG co-exist with a user-owned AGENTS.md instead
+of clobbering it. The generated content lives between HTML-comment markers:
+
+    <!-- LFG:BEGIN v0.4.0 — DO NOT EDIT BETWEEN THESE MARKERS -->
+    <generated body>
+    <!-- LFG:END -->
+
+`merge_into_existing` decides, given the current file contents and a freshly
+rendered block, what the new file should be — preserving user content above and
+below the markers, refusing to downgrade a newer-managed block, and recognizing
+a pre-marker LFG AGENTS.md (the v0.3.0 bridge) by fingerprint.
+
+Pure string logic + a pair of encoding-safe IO helpers (mirroring archive.py's
+patterns). No argparse, no side effects at import — the CLI wiring is T5.
+
+Encoding & atomicity policy (Spec 4 §1):
+  - Read with utf-8-sig (strips BOM), normalize CRLF/CR -> LF.
+  - Write LF, UTF-8, no BOM, atomically (tmp file + fsync + os.replace).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+# --- Markers (mirror generator.py / the spec's strict regex) ----------------
+
+LFG_BEGIN_RE = re.compile(r"<!--\s*LFG:BEGIN\s+v(?P<ver>\S+)\s*(?:—[^>]*)?-->")
+LFG_END_LIT = "<!-- LFG:END -->"
+
+
+class ForwardVersionError(Exception):
+    """Raised when the existing managed block was written by a newer LFG.
+
+    Refuses to silently overwrite a future block schema. The CLI offers
+    --force-downgrade as the escape hatch (a separate path that does not call
+    this with the refusal in place).
+    """
+
+
+class CorruptMarkerError(Exception):
+    """Raised when the existing AGENTS.md has a half-broken managed block.
+
+    A BEGIN marker with no valid END (END absent, or END appearing *before*
+    BEGIN) means we cannot safely slice out the managed region. Falling through
+    to the prepend branch would emit a second BEGIN marker and let a later merge
+    mis-slice the file, silently corrupting or losing user content. So we stop.
+
+    This is distinct from ForwardVersionError: a forward-version block is
+    well-formed (just newer); a corrupt block is structurally broken and the
+    user must fix it by hand. There is deliberately no flag that auto-resolves
+    it (not even --no-wrap) — see merge_into_existing for why.
+    """
+
+
+# --- Version comparator (reuse check-version.py; do not reinvent semver) -----
+#
+# check-version.py has a hyphen in its name and is not importable by `import`,
+# so load it once via importlib from its file path (same approach the existing
+# test_check_version.py uses).
+
+def _load_compare_versions():
+    scripts_dir = Path(__file__).resolve().parent
+    spec = importlib.util.spec_from_file_location(
+        "_lfg_check_version", scripts_dir / "check-version.py"
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError("could not load check-version.py for version comparison")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.compare_versions
+
+
+_compare_versions = _load_compare_versions()
+
+
+# --- Fingerprint -------------------------------------------------------------
+
+def _parse_leading_frontmatter(content: str) -> Optional[dict[str, str]]:
+    """Parse a leading `---`-delimited YAML frontmatter block into a flat dict.
+
+    Only the top-level `key: value` lines are captured (enough for the doc:
+    AGENTS check). Returns None when the file does not open with a frontmatter
+    block. Leading whitespace/blank lines before the first `---` are tolerated.
+    """
+    lines = content.splitlines()
+    # Skip leading blank lines.
+    idx = 0
+    while idx < len(lines) and lines[idx].strip() == "":
+        idx += 1
+    if idx >= len(lines) or lines[idx].strip() != "---":
+        return None
+
+    fm: dict[str, str] = {}
+    for line in lines[idx + 1:]:
+        if line.strip() == "---":
+            return fm
+        if ":" not in line:
+            continue
+        # Only capture top-level (non-indented) keys.
+        if line[:1] in (" ", "\t"):
+            continue
+        key, _, value = line.partition(":")
+        fm[key.strip()] = value.strip()
+    # No closing delimiter found -> not a well-formed frontmatter block.
+    return None
+
+
+def looks_like_lfg(content: str) -> bool:
+    """Fingerprint an unmarked AGENTS.md as LFG-generated (pre-marker bridge).
+
+    PRIMARY signal (sufficient alone): YAML frontmatter with a `doc: AGENTS`
+    line. Present in v0.3.0 and HEAD; absent from hand-authored / Codex /
+    Aider AGENTS.md files.
+
+    DEFENSIVE fallback (only when frontmatter is absent/stripped) — TRUE if
+    >=2 of:
+      - 'Log File Genius' in the first 200 chars
+      - all of 'lfg validate', 'lfg prime', 'lfg generate'
+      - all of 'logs/STATE.md', 'logs/CHANGELOG.md', 'logs/DEVLOG.md'
+    """
+    if not content:
+        return False
+
+    # Primary: frontmatter doc: AGENTS.
+    fm = _parse_leading_frontmatter(content)
+    if fm is not None and fm.get("doc") == "AGENTS":
+        return True
+
+    # Defensive fallback.
+    head = content[:200]
+    signals = 0
+    if "Log File Genius" in head:
+        signals += 1
+    if all(cmd in content for cmd in ("lfg validate", "lfg prime", "lfg generate")):
+        signals += 1
+    if all(
+        path in content
+        for path in ("logs/STATE.md", "logs/CHANGELOG.md", "logs/DEVLOG.md")
+    ):
+        signals += 1
+    return signals >= 2
+
+
+# --- Merge -------------------------------------------------------------------
+
+def merge_into_existing(
+    existing: Optional[str],
+    block: str,
+    running_version: str,
+    allow_wrap: bool = True,
+    force_downgrade: bool = False,
+) -> str:
+    """Return the new AGENTS.md content.
+
+    1. existing is None or blank -> return block (fresh install).
+    2. existing has BEGIN + END markers:
+         - captured version > running_version -> raise ForwardVersionError,
+           UNLESS force_downgrade is True (then replace the interior anyway).
+         - else replace everything from BEGIN through END (inclusive) with
+           block; content before BEGIN and after END is preserved verbatim.
+    3. existing has no markers + looks_like_lfg + allow_wrap -> return block.
+    4. existing has no markers + (not LFG or allow_wrap False) -> prepend
+       block + blank line at the top, keep all user content below.
+    """
+    if existing is None or existing.strip() == "":
+        return block
+
+    begin_match = LFG_BEGIN_RE.search(existing)
+    end_idx = existing.find(LFG_END_LIT)
+
+    # Corrupt half-marker guard (BLOCKER 1): a BEGIN with no usable END.
+    # If END is absent, or END sits before the BEGIN match ends, we cannot
+    # slice the managed region safely. Falling through to prepend would emit a
+    # SECOND BEGIN marker and let a later merge mis-slice the file. Refuse
+    # ALWAYS — even with allow_wrap False (the --no-wrap CLI flag). The user
+    # must repair the file by hand or overwrite it. There is no auto-fix here
+    # by design: silently picking one of two BEGIN markers is exactly the
+    # self-corrupting behavior this guard exists to prevent.
+    if begin_match is not None and (end_idx == -1 or end_idx <= begin_match.end()):
+        raise CorruptMarkerError(
+            "AGENTS.md has an LFG:BEGIN marker but no valid END marker "
+            "(corrupt). Fix manually or pass --no-wrap to overwrite."
+        )
+
+    # Case 2: a complete managed block is present.
+    if begin_match is not None and end_idx != -1 and end_idx > begin_match.start():
+        captured = begin_match.group("ver")
+        # compare returns None for an unparseable captured version; in that
+        # case we cannot confirm the block is "forward", so we do NOT refuse —
+        # we treat it as replaceable rather than raising on junk.
+        relation = _compare_versions(captured, running_version)
+        if not force_downgrade and relation is not None and relation > 0:
+            raise ForwardVersionError(
+                f"AGENTS.md was managed by a newer LFG (v{captured} > "
+                f"v{running_version}). Upgrade the submodule or pass "
+                f"--force-downgrade."
+            )
+        before = existing[: begin_match.start()]
+        after = existing[end_idx + len(LFG_END_LIT):]
+        # block ends in exactly one "\n". Absorb a single newline that follows
+        # the END literal into the managed region so the block/after boundary is
+        # not double-counted — this keeps the merge idempotent when user content
+        # sits below the block (re-running the merge reproduces the same `after`).
+        if after.startswith("\n"):
+            after = after[1:]
+        return before + block + after
+
+    # Case 3: pre-marker LFG content (e.g. a v0.3.0 install) + wrap allowed.
+    #
+    # The spec describes this as "wrap the entire existing content in markers,
+    # then replace the interior with block." Wrapping freshly and then replacing
+    # the interior with `block` discards the old body entirely, so the net
+    # result is simply `block`. That is intended: the old unmarked body is stale
+    # LFG content being regenerated — no user content is lost because there is
+    # none outside the (notional) markers. Returning `block` is the correct,
+    # simplest implementation of that equivalence.
+    if begin_match is None and allow_wrap and looks_like_lfg(existing):
+        return block
+
+    # Case 4: user-authored content (or wrapping disabled). Prepend the block,
+    # keep all user content below, untouched.
+    return block + "\n" + existing
+
+
+# --- Encoding / IO helpers (mirror archive.py style) -------------------------
+
+def read_text_normalized(path: str | os.PathLike[str]) -> str:
+    """Read a file as text: strip a UTF-8 BOM, normalize line endings to LF.
+
+    Returns "" if the file does not exist. Marker regexes operate on the
+    normalized content only (Spec 4 §1).
+    """
+    p = Path(path)
+    if not p.exists():
+        return ""
+    text = p.read_text(encoding="utf-8-sig")
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def atomic_write(path: str | os.PathLike[str], content: str) -> None:
+    """Write content atomically as UTF-8, LF, no BOM.
+
+    Writes to <path>.lfg-tmp, flushes + fsyncs, then os.replace() onto the
+    target. A crash mid-write leaves the original file intact. On ANY failure
+    (write, fsync, or replace) the tmp file is unlinked so we never leave a
+    stray <path>.lfg-tmp behind; the original target is untouched until the
+    atomic os.replace succeeds.
+    """
+    p = Path(path)
+    tmp = p.with_name(p.name + ".lfg-tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, p)
+    except BaseException:
+        # Clean up the tmp file on any failure (including the replace). The
+        # original target is left exactly as it was.
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise

--- a/product/scripts/check-version.py
+++ b/product/scripts/check-version.py
@@ -22,7 +22,117 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
+
+
+# --- Semver-ish version comparison -----------------------------------------
+#
+# Used by the validators to decide whether an installed version is ahead of,
+# behind, or equal to the latest-known version. Handles:
+#   - normal X.Y.Z
+#   - pre-release suffix (1.2.3-rc.1) — sorts BEFORE its release (1.2.3)
+#   - build metadata (1.2.3+local.abc) — ignored for precedence
+# Follows semver.org precedence rules (minus exotic edge cases we don't ship).
+
+_VersionParts = Tuple[Tuple[int, int, int], Tuple[Union[int, str], ...]]
+
+
+class UnparseableVersionError(ValueError):
+    """Raised when a version string has no numeric core (e.g. "" or "abc").
+
+    A leading 'v', missing minor/patch (1.2), and pre-release/build suffixes
+    are all VALID and do NOT raise — only truly non-numeric input where even
+    the major component isn't an integer. Callers that compare versions treat
+    this as "cannot determine direction" rather than guessing.
+    """
+
+
+def parse_version(version: str) -> _VersionParts:
+    """Parse a version string into ((major, minor, patch), prerelease_ids).
+
+    Build metadata (everything after '+') is stripped and ignored.
+    A missing pre-release is represented by an empty tuple, which always
+    sorts *after* any non-empty pre-release (per semver precedence).
+    A leading 'v' (e.g. "v0.4.0") is tolerated.
+    Missing minor/patch components default to 0.
+
+    Raises UnparseableVersionError when the input is junk (empty / non-numeric
+    major), so garbage like "" or "abc" can't masquerade as (0, 0, 0) and make
+    every real version look "ahead" — which previously triggered spurious
+    "update available" nags.
+    """
+    text = version.strip()
+    if text.startswith("v") or text.startswith("V"):
+        text = text[1:]
+
+    # Build metadata does not affect precedence — discard it.
+    text = text.split("+", 1)[0]
+
+    # Split off the pre-release segment (first '-').
+    core, _, prerelease = text.partition("-")
+
+    nums = core.split(".")
+    # The major component MUST be a non-negative integer. Anything else
+    # (empty string, "abc", "1.x" where even major is bad) is junk.
+    if len(nums) == 0 or not nums[0].isdigit():
+        raise UnparseableVersionError(f"unparseable version: {version!r}")
+    major = int(nums[0])
+    minor = int(nums[1]) if len(nums) > 1 and nums[1].isdigit() else 0
+    patch = int(nums[2]) if len(nums) > 2 and nums[2].isdigit() else 0
+
+    pre_ids: Tuple[Union[int, str], ...] = ()
+    if prerelease:
+        ids: List[Union[int, str]] = []
+        for ident in prerelease.split("."):
+            ids.append(int(ident) if ident.isdigit() else ident)
+        pre_ids = tuple(ids)
+
+    return (major, minor, patch), pre_ids
+
+
+def _prerelease_key(pre_ids: Tuple[Union[int, str], ...]) -> tuple:
+    """Sort key for the pre-release segment honoring semver rules.
+
+    - No pre-release outranks any pre-release: (1,) > (0, ...).
+    - Numeric identifiers compare numerically and rank below alphanumerics.
+    """
+    if not pre_ids:
+        # Release version: sorts after any pre-release.
+        return (1,)
+    key: List[tuple] = []
+    for ident in pre_ids:
+        if isinstance(ident, int):
+            key.append((0, ident, ""))
+        else:
+            key.append((1, 0, ident))
+    return (0, tuple(key))
+
+
+def compare_versions(a: str, b: str) -> Optional[int]:
+    """Compare two versions. Returns -1 if a < b, 0 if equal, 1 if a > b.
+
+    Returns None when EITHER side is unparseable junk (empty / non-numeric).
+    Callers must treat None as "cannot determine direction" and stay silent
+    rather than guess — a guessed direction is exactly the bug that produced
+    spurious "update available" nags.
+
+    Build metadata is ignored; pre-release versions sort before their
+    associated release.
+    """
+    try:
+        core_a, pre_a = parse_version(a)
+        core_b, pre_b = parse_version(b)
+    except UnparseableVersionError:
+        return None
+
+    if core_a != core_b:
+        return -1 if core_a < core_b else 1
+
+    key_a = _prerelease_key(pre_a)
+    key_b = _prerelease_key(pre_b)
+    if key_a == key_b:
+        return 0
+    return -1 if key_a < key_b else 1
 
 
 def get_script_dir() -> Path:
@@ -55,15 +165,24 @@ def save_version_manifest(manifest: Dict):
 
 
 def compute_file_checksum(file_path: Path) -> Optional[str]:
-    """Compute SHA256 checksum of a file"""
+    """Compute a content checksum that is stable across platforms.
+
+    Text files in this repo are re-encoded by git on checkout: `.ps1` files
+    carry a UTF-8 BOM and become CRLF on Windows, while `.py`/`.sh` stay LF.
+    Hashing raw bytes therefore yields a different digest per platform, so a
+    fixed baseline in VERSION.json could never pass everywhere. We normalize
+    away those checkout artifacts (strip a leading UTF-8 BOM, fold CRLF/CR to
+    LF) before hashing, so the checksum reflects file *content*, not the
+    line-ending/BOM encoding git happened to apply. This matches the
+    UTF-8/LF/no-BOM read policy used elsewhere (agents_merge)."""
     if not file_path.exists():
         return None
-    
-    sha256 = hashlib.sha256()
-    with open(file_path, 'rb') as f:
-        for chunk in iter(lambda: f.read(8192), b''):
-            sha256.update(chunk)
-    return sha256.hexdigest()[:16]  # First 16 chars for brevity
+
+    raw = file_path.read_bytes()
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raw = raw[3:]
+    normalized = raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return hashlib.sha256(normalized).hexdigest()[:16]  # First 16 chars for brevity
 
 
 def check_version_sync(manifest: Dict) -> List[str]:
@@ -157,9 +276,25 @@ def main():
     parser = argparse.ArgumentParser(description="Check Log File Genius version synchronization")
     parser.add_argument('--update', action='store_true', help="Update checksums in VERSION.json")
     parser.add_argument('--json', action='store_true', help="Output as JSON")
-    
+    parser.add_argument('--compare', nargs=2, metavar=('INSTALLED', 'LATEST'),
+                        help="Compare two versions. Prints 'ahead', 'behind', or "
+                             "'current' (exit 0); prints 'unknown' and exits 1 "
+                             "if either version is unparseable.")
+
     args = parser.parse_args()
-    
+
+    # Lightweight version-comparison mode for the validators (no manifest needed).
+    if args.compare:
+        installed, latest = args.compare
+        result = compare_versions(installed, latest)
+        if result is None:
+            # Unparseable input: emit a neutral token and exit non-zero so the
+            # shell/PS validators DON'T print a direction they can't verify.
+            print("unknown")
+            sys.exit(1)
+        print("ahead" if result > 0 else "behind" if result < 0 else "current")
+        sys.exit(0)
+
     manifest = load_version_manifest()
     
     # Check version synchronization

--- a/product/scripts/generator.py
+++ b/product/scripts/generator.py
@@ -1,16 +1,28 @@
 """Generator: fragments -> AGENTS.md.
 
-Pure functions: parse_fragment(path) returns (frontmatter_dict, body_str);
-render_agents_md(fragments) returns the rendered AGENTS.md string. Neither
-function does I/O on AGENTS.md itself — the caller writes.
+Pure functions: parse_fragment(path) returns (frontmatter_dict, body_str).
+
+Rendering has one primitive and two wrappers (Spec 4 §1):
+  - render_canonical_body(fragments) -> the canonical AGENTS.md content
+    (frontmatter + intro + section index + all fragment bodies), no markers.
+  - render_full(fragments) -> alias for render_canonical_body. This is what
+    writes the in-repo product/AGENTS.md (fully LFG-owned, no markers).
+  - render_block(fragments) -> the canonical body wrapped in LFG:BEGIN/END
+    managed-block markers. Used by the install/update merge.
+
+render_agents_md remains as a backward-compatible alias for render_full so
+existing callers (lfg.py `generate`) keep producing byte-identical output.
+None of these do I/O on AGENTS.md itself — the caller writes.
 
 Output is LF, UTF-8 (no BOM), single trailing newline. Fails loudly on
 malformed frontmatter or above-budget output. Same inputs => byte-identical
 output (idempotent).
 """
 from __future__ import annotations
+import json
+import re
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 AGENTS_TOKEN_BUDGET = 4500  # chars/4 heuristic. Re-bumped to 4500 after T11's
 # subagent contract block landed AGENTS.md at 3999/4000 — zero headroom would
@@ -79,7 +91,13 @@ def parse_fragment(path: Path) -> Tuple[Dict[str, Any], str]:
     return fm, body
 
 
-def render_agents_md(fragments: List[Tuple[Dict[str, Any], str]]) -> str:
+def render_canonical_body(fragments: List[Tuple[Dict[str, Any], str]]) -> str:
+    """Emit the canonical AGENTS.md content (no enclosing markers).
+
+    This is the single source of truth for AGENTS.md content: frontmatter +
+    intro + available commands + section index + all fragment bodies. It is
+    exactly what product/AGENTS.md contains today.
+    """
     # Keep only fragments destined for AGENTS.md; sort by order.
     in_agents = [f for f in fragments if "agents_md" in f[0].get("targets", [])]
     in_agents.sort(key=lambda fb: fb[0]["order"])
@@ -142,3 +160,88 @@ def render_agents_md(fragments: List[Tuple[Dict[str, Any], str]]) -> str:
             "compress fragments or raise the budget intentionally"
         )
     return out
+
+
+def render_full(fragments: List[Tuple[Dict[str, Any], str]]) -> str:
+    """Return the canonical body unchanged.
+
+    Used to emit the in-repo product/AGENTS.md, which is fully LFG-owned and
+    carries no markers.
+    """
+    return render_canonical_body(fragments)
+
+
+# Backward-compatible alias for the original public entry point. lfg.py's
+# `generate` command imports this name; keeping it identical to render_full
+# guarantees byte-identical output (the CI drift gate `lfg generate --check`).
+render_agents_md = render_full
+
+
+# --- Managed-block markers (Spec 4 §1) --------------------------------------
+
+# BEGIN line uses an em-dash separator exactly as the spec shows. The strip
+# regex below matches the spec's strict BEGIN regex so render_block output is
+# round-trippable back to render_full output.
+_BLOCK_BEGIN_TEMPLATE = "<!-- LFG:BEGIN v{version} — DO NOT EDIT BETWEEN THESE MARKERS -->"
+_BLOCK_END = "<!-- LFG:END -->"
+
+# Mirror of the spec's BEGIN-marker regex:
+#   <!--\s*LFG:BEGIN\s+v(\S+)\s*(?:—[^>]*)?-->
+_BLOCK_BEGIN_RE = re.compile(r"<!--\s*LFG:BEGIN\s+v(\S+)\s*(?:—[^>]*)?-->")
+
+
+def read_repo_version() -> str:
+    """Read the `version` field from product/VERSION.json.
+
+    Follows the same lookup pattern as check-version.py: VERSION.json lives in
+    the product/ directory (the parent of this scripts/ dir).
+    """
+    version_file = Path(__file__).resolve().parent.parent / "VERSION.json"
+    with open(version_file, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    version = manifest.get("version")
+    if not version:
+        raise GeneratorError(f"VERSION.json missing 'version' field at {version_file}")
+    return str(version)
+
+
+def render_block(
+    fragments: List[Tuple[Dict[str, Any], str]],
+    version: Optional[str] = None,
+) -> str:
+    """Wrap the canonical body in LFG:BEGIN/END managed-block markers.
+
+    The BEGIN marker captures the running LFG version (from VERSION.json by
+    default). Used by the install/update merge so the block can be located and
+    rewritten in place without clobbering surrounding user content.
+
+    Output is LF, UTF-8-safe, single trailing newline.
+    """
+    if version is None:
+        version = read_repo_version()
+    body = render_canonical_body(fragments)
+    begin = _BLOCK_BEGIN_TEMPLATE.format(version=version)
+    # body already ends in exactly one "\n"; emit BEGIN + body + END + newline.
+    return f"{begin}\n{body}{_BLOCK_END}\n"
+
+
+def strip_block_markers(text: str) -> str:
+    """Inverse of render_block: return the canonical body inside the markers.
+
+    Strips the BEGIN line (matching the spec's strict regex) and the literal
+    END line, returning the interior byte-for-byte as render_full would emit
+    it. Raises GeneratorError if the markers are not found.
+    """
+    begin_match = _BLOCK_BEGIN_RE.search(text)
+    if begin_match is None:
+        raise GeneratorError("no LFG:BEGIN marker found")
+    end_idx = text.find(_BLOCK_END)
+    if end_idx == -1:
+        raise GeneratorError("no LFG:END marker found")
+
+    # Interior starts after the BEGIN line's trailing newline.
+    body_start = text.find("\n", begin_match.end())
+    if body_start == -1:
+        raise GeneratorError("malformed block: BEGIN marker has no following newline")
+    body_start += 1
+    return text[body_start:end_idx]

--- a/product/scripts/install.ps1
+++ b/product/scripts/install.ps1
@@ -302,14 +302,53 @@ if ($AiAssistant -eq "claude-code") {
     Print-Success "Rendered .claude/project_instructions.md"
 }
 
-$agentsSrc = Join-Path $SourceRoot "AGENTS.md"
-if (Test-Path $agentsSrc) {
-    # Re-emit with LF + no BOM in case the source was checked out CRLF.
-    $agentsText = (Get-Content $agentsSrc -Raw) -replace "`r`n", "`n"
-    $agentsDest = Join-Path $ProjectRoot "AGENTS.md"
-    [System.IO.File]::WriteAllText($agentsDest, $agentsText, (New-Object System.Text.UTF8Encoding $false))
-    $CreatedItems += $agentsDest
-    Print-Success "Installed AGENTS.md at project root"
+# Merge the canonical managed block into the project-root AGENTS.md.
+# Brownfield-safe: the merge CLI (lfg.py merge-agents-md) builds the
+# marker-wrapped block from product/rules/ and either creates the file,
+# refreshes the managed block in place, wraps a pre-marker LFG body, or
+# prepends above user content (printing which case applied). It writes
+# UTF-8 LF no-BOM and is idempotent. Never clobbers user-owned content.
+$lfgPy = Join-Path $ScriptDir "lfg.py"
+$agentsDest = Join-Path $ProjectRoot "AGENTS.md"
+$agentsPreexisting = Test-Path $agentsDest
+
+# Resolve a python interpreter the same way validate-log-files.ps1 does.
+$python = $null
+if (Get-Command python -ErrorAction SilentlyContinue) { $python = "python" }
+elseif (Get-Command python3 -ErrorAction SilentlyContinue) { $python = "python3" }
+
+if ($python -and (Test-Path $lfgPy)) {
+    & $python $lfgPy merge-agents-md --to $agentsDest
+    if ($LASTEXITCODE -eq 0) {
+        # Only track for rollback if WE created it — merging into a pre-existing
+        # user file must never be rolled back (that would lose their content).
+        if (-not $agentsPreexisting) { $CreatedItems += $agentsDest }
+        Print-Success "Merged AGENTS.md managed block at project root"
+    }
+    else {
+        # Non-zero = corrupt marker or forward-version block; the merge left the
+        # file untouched. Don't abort the install — everything else succeeded.
+        Print-Warning "AGENTS.md was left as-is (merge could not complete safely)."
+        Print-Warning "Resolve it manually, then re-run: $python `"$lfgPy`" merge-agents-md --to `"$agentsDest`""
+    }
+}
+else {
+    # No python available: degrade gracefully. Only fall back to the old copy
+    # behavior when the target does NOT already exist — never overwrite an
+    # existing AGENTS.md without the merge (preserves the no-data-loss guarantee).
+    $agentsSrc = Join-Path $SourceRoot "AGENTS.md"
+    if ($agentsPreexisting) {
+        Print-Warning "python not found and AGENTS.md already exists; skipped (will not overwrite)."
+        Print-Warning "Install python and re-run: <python> `"$lfgPy`" merge-agents-md --to `"$agentsDest`""
+    }
+    elseif (Test-Path $agentsSrc) {
+        # Re-emit with LF + no BOM in case the source was checked out CRLF.
+        $agentsText = (Get-Content $agentsSrc -Raw) -replace "`r`n", "`n"
+        [System.IO.File]::WriteAllText($agentsDest, $agentsText, (New-Object System.Text.UTF8Encoding $false))
+        $CreatedItems += $agentsDest
+        Print-Warning "python not found; copied AGENTS.md verbatim (no managed-block merge)."
+        Print-Success "Installed AGENTS.md at project root"
+    }
 }
 
 # ============================================================================

--- a/product/scripts/install.sh
+++ b/product/scripts/install.sh
@@ -306,14 +306,51 @@ if [ "$AI_ASSISTANT" = "claude-code" ]; then
     print_success "Rendered .claude/project_instructions.md"
 fi
 
-# Drop AGENTS.md at the project root for tools that read it natively.
-# Strip CRLF in case the source was checked out on Windows with autocrlf — the
-# generator's contract is LF-only, and tools shouldn't see a mixed-line-ending
-# file just because of where the user cloned the repo.
-if [ -f "$SOURCE_ROOT/AGENTS.md" ]; then
-    tr -d '\r' < "$SOURCE_ROOT/AGENTS.md" > "$PROJECT_ROOT/AGENTS.md"
-    CREATED_ITEMS+=("$PROJECT_ROOT/AGENTS.md")
-    print_success "Installed AGENTS.md at project root"
+# Merge the canonical managed block into the project-root AGENTS.md.
+# This is brownfield-safe: it never clobbers user-owned content. The merge CLI
+# (lfg.py merge-agents-md) builds the marker-wrapped block from product/rules/
+# and either creates the file, refreshes the managed block in place, wraps a
+# pre-marker LFG body, or prepends above user content — printing which case
+# applied. Idempotent re-runs write nothing.
+LFG_PY="$SCRIPT_DIR/lfg.py"
+AGENTS_TARGET="$PROJECT_ROOT/AGENTS.md"
+AGENTS_PREEXISTING=false
+[ -f "$AGENTS_TARGET" ] && AGENTS_PREEXISTING=true
+
+# Resolve a python interpreter the same way validate-log-files.sh does.
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+fi
+
+if [ -n "$PYTHON_BIN" ] && [ -f "$LFG_PY" ]; then
+    if "$PYTHON_BIN" "$LFG_PY" merge-agents-md --to "$AGENTS_TARGET"; then
+        # Only track for rollback if WE created it (merge into a pre-existing
+        # user file must never be rolled back — that would lose their content).
+        [ "$AGENTS_PREEXISTING" = "false" ] && CREATED_ITEMS+=("$AGENTS_TARGET")
+        print_success "Merged AGENTS.md managed block at project root"
+    else
+        # Non-zero = corrupt marker or forward-version block. The merge left the
+        # file untouched. Don't abort the install — everything else succeeded.
+        print_warning "AGENTS.md was left as-is (merge could not complete safely)."
+        print_warning "Resolve it manually, then re-run: $PYTHON_BIN $LFG_PY merge-agents-md --to \"$AGENTS_TARGET\""
+    fi
+elif [ -f "$SOURCE_ROOT/AGENTS.md" ]; then
+    # No python available: degrade gracefully. Only fall back to the old copy
+    # behavior when the target does NOT already exist — never overwrite an
+    # existing AGENTS.md without the merge (preserves the no-data-loss guarantee).
+    if [ "$AGENTS_PREEXISTING" = "true" ]; then
+        print_warning "python not found and AGENTS.md already exists; skipped (will not overwrite)."
+        print_warning "Install python and re-run: <python> $LFG_PY merge-agents-md --to \"$AGENTS_TARGET\""
+    else
+        # Strip CRLF in case the source was checked out on Windows with autocrlf.
+        tr -d '\r' < "$SOURCE_ROOT/AGENTS.md" > "$AGENTS_TARGET"
+        CREATED_ITEMS+=("$AGENTS_TARGET")
+        print_warning "python not found; copied AGENTS.md verbatim (no managed-block merge)."
+        print_success "Installed AGENTS.md at project root"
+    fi
 fi
 
 # ============================================================================

--- a/product/scripts/known_template_hashes.json
+++ b/product/scripts/known_template_hashes.json
@@ -1,0 +1,20 @@
+{
+  "0.3.0": {
+    ".logfile-config.yml": "90a4f61a82ba6b3be7ac16cab3844f78a79593e38e26233b7917d7c64e2fe38b",
+    "ADR_template.md": "6893acdeb7fed0f35ae080813274fbe604a3a80648053b033e49245bbeb4ed1d",
+    "CHANGELOG_template.md": "c11a02bf21b0b2b4b472acbad9951cb5e7f2c7040b97f29d1b9bc84ee6f8241a",
+    "DEVLOG_template.md": "1a33af384fe15d216277ce0e229502f48494f692baff79019bf1db4d3cf55d78",
+    "MIGRATION_GUIDE_template.md": "a02a165874977ff2e727d550c5d81805bb5b400016813a36a0ccc8cdf4d8537b",
+    "README.md": "c5e71114164fd479673f9d10dfbde65ae3d4aebe23c20095e8ff9de8e2bb8f0f",
+    "STATE_template.md": "b08fe7638bc5c02de304870f1e915b110f0f4f5d70ddf5b09101ae6a1cc396f0"
+  },
+  "0.4.0": {
+    ".logfile-config.yml": "90a4f61a82ba6b3be7ac16cab3844f78a79593e38e26233b7917d7c64e2fe38b",
+    "ADR_template.md": "6893acdeb7fed0f35ae080813274fbe604a3a80648053b033e49245bbeb4ed1d",
+    "CHANGELOG_template.md": "c11a02bf21b0b2b4b472acbad9951cb5e7f2c7040b97f29d1b9bc84ee6f8241a",
+    "DEVLOG_template.md": "1a33af384fe15d216277ce0e229502f48494f692baff79019bf1db4d3cf55d78",
+    "MIGRATION_GUIDE_template.md": "a02a165874977ff2e727d550c5d81805bb5b400016813a36a0ccc8cdf4d8537b",
+    "README.md": "c5e71114164fd479673f9d10dfbde65ae3d4aebe23c20095e8ff9de8e2bb8f0f",
+    "STATE_template.md": "b08fe7638bc5c02de304870f1e915b110f0f4f5d70ddf5b09101ae6a1cc396f0"
+  }
+}

--- a/product/scripts/lfg.py
+++ b/product/scripts/lfg.py
@@ -46,9 +46,16 @@ def cmd_validate(args):
     # Build arguments for lint-logs
     sys.argv = ['lint-logs']
     if args.changelog:
-        sys.argv.append('--changelog-only')
+        sys.argv.append('--changelog')
     if args.devlog:
-        sys.argv.append('--devlog-only')
+        sys.argv.append('--devlog')
+    if getattr(args, 'state_only', False):
+        # STATE-only mode: validate STATE.md alone so callers (e.g.
+        # update.{sh,ps1}) can detect a STATE-specific failure without
+        # false-positiving on CHANGELOG/DEVLOG issues. Exits 2 iff STATE.md
+        # has errors (e.g. missing '## Current Context'); budget warnings
+        # stay exit 0 unless --strict is also passed through lint-logs.
+        sys.argv.append('--state')
     if args.verbose:
         sys.argv.append('--verbose')
     if args.json:
@@ -190,6 +197,131 @@ def cmd_generate(args):
     return 0
 
 
+def cmd_merge_agents_md(args):
+    """Merge the canonical managed block into a target AGENTS.md (brownfield-safe).
+
+    Builds the marker-wrapped block from the rules fragments (same loading path
+    as cmd_generate), then merges it into the target via agents_merge, preserving
+    any surrounding user content. Idempotent: re-running on an up-to-date file
+    writes nothing.
+    """
+    import agents_merge
+    import generator
+    from generator import parse_fragment, GeneratorError
+
+    rules_dir = Path(__file__).resolve().parent.parent / "rules"
+    if not rules_dir.is_dir():
+        print(f"ERROR: rules dir not found at {rules_dir}", file=sys.stderr)
+        return 2
+
+    fragments = []
+    for p in sorted(rules_dir.glob("*.md")):
+        try:
+            fragments.append(parse_fragment(p))
+        except GeneratorError as e:
+            print(f"ERROR: {p.name}: {e}", file=sys.stderr)
+            return 2
+
+    try:
+        running_version = generator.read_repo_version()
+        block = generator.render_block(fragments, version=running_version)
+    except GeneratorError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    existing = agents_merge.read_text_normalized(args.to)
+
+    # Pre-merge visibility (SHOULD-FIX 4): inspect `existing` read-only to tell
+    # the user WHICH merge case will apply before we write. Especially the wrap
+    # case (old LFG body replaced) and the prepend case (user content kept).
+    # This does not change merge_into_existing's behavior or return type.
+    begin_match = agents_merge.LFG_BEGIN_RE.search(existing)
+    has_begin = begin_match is not None
+    end_idx = existing.find(agents_merge.LFG_END_LIT)
+    has_valid_block = has_begin and end_idx != -1 and end_idx > begin_match.end()
+    # The wrap-replace path is the ONLY one that discards existing content: an
+    # unmarked file that fingerprints as LFG (e.g. a v0.3.0 AGENTS.md) has its
+    # whole body replaced, because without markers we cannot tell where old LFG
+    # content ends and a user's additions begin. To honor "never lose user
+    # content", we back the original up before replacing (see below).
+    will_wrap_replace = bool(
+        existing.strip()
+        and not has_valid_block
+        and not args.no_wrap
+        and agents_merge.looks_like_lfg(existing)
+    )
+    if not existing.strip():
+        print(f"No existing AGENTS.md; creating managed block at {args.to}.")
+    elif has_begin and not has_valid_block:
+        # Corrupt half-marker — say nothing positive; the error path handles it.
+        pass
+    elif has_valid_block:
+        print(f"Existing AGENTS.md has an LFG managed block; refreshing it in place: {args.to}")
+    elif will_wrap_replace:
+        print("Existing AGENTS.md matched LFG content; regenerating managed block "
+              "(original backed up first -- see below).")
+    else:
+        print("Existing AGENTS.md preserved; LFG block prepended above your content.")
+
+    try:
+        merged = agents_merge.merge_into_existing(
+            existing or None,
+            block,
+            running_version,
+            allow_wrap=not args.no_wrap,
+            force_downgrade=args.force_downgrade,
+        )
+    except agents_merge.ForwardVersionError:
+        # Re-extract the captured version for a precise message.
+        match = agents_merge.LFG_BEGIN_RE.search(existing)
+        captured = match.group("ver") if match else "?"
+        print(
+            f"ERROR: AGENTS.md at {args.to} was managed by a newer LFG "
+            f"(v{captured}). Re-run with --force-downgrade to overwrite.",
+            file=sys.stderr,
+        )
+        return 2
+    except agents_merge.CorruptMarkerError:
+        # Half-broken managed block (BEGIN with no valid END). We refuse rather
+        # than risk emitting a second BEGIN marker that a later merge would
+        # mis-slice. This errors regardless of --no-wrap — the user must repair
+        # the file by hand (ASCII-only message for cross-platform consoles).
+        print(
+            f"ERROR: AGENTS.md at {args.to} has an LFG:BEGIN marker but no "
+            f"valid END marker (corrupt). Fix it manually, then re-run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Idempotency short-circuit: compare against the RAW on-disk bytes, not the
+    # normalized read. atomic_write emits UTF-8, LF, no BOM, so the post-write
+    # bytes equal merged.encode("utf-8"). Comparing raw means a file that only
+    # differs by a UTF-8 BOM or CRLF line endings is NOT treated as up-to-date —
+    # it still gets a normalizing rewrite, honoring the encoding policy.
+    target_path = Path(args.to)
+    raw_existing = target_path.read_bytes() if target_path.is_file() else b""
+    if raw_existing == merged.encode("utf-8"):
+        print(f"AGENTS.md already up to date (no change): {args.to}")
+        return 0
+
+    # Safety net for the lossy wrap-replace path: preserve the original bytes in
+    # a sibling backup before overwriting, so a user who added their own notes to
+    # a pre-marker (v0.3.0) AGENTS.md can recover them. Pick the first free
+    # `<name>.bak`, `<name>.bak.2`, ... so we never clobber an existing backup.
+    if will_wrap_replace and raw_existing:
+        backup = target_path.with_name(target_path.name + ".bak")
+        n = 2
+        while backup.exists():
+            backup = target_path.with_name(f"{target_path.name}.bak.{n}")
+            n += 1
+        backup.write_bytes(raw_existing)
+        print(f"Backed up previous AGENTS.md to {backup}")
+
+    agents_merge.atomic_write(args.to, merged)
+    print(f"Updated {args.to}")
+    return 0
+
+
 def cmd_prime(args):
     """Emit a subagent context digest (STATE + last N CHANGELOG entries)."""
     from primer import build_prime
@@ -271,6 +403,73 @@ def cmd_archive(args):
     return 0
 
 
+def cmd_migrate_state(args):
+    """Build a STATE migration plan and (if not --dry-run) apply it.
+
+    Mirrors cmd_archive: resolve config + STATE/DEVLOG paths, build the plan,
+    stream it to stdout, then either dry-run (write nothing), prompt+apply, or
+    --force-apply. The two MigrateError guards (already-compliant/empty plan, or
+    already-migrated snapshot in DEVLOG) are NOT failures — they're no-ops, so
+    they print a clear ASCII message and return 0.
+
+    today's date is sourced here at the CLI layer (the pure planner/apply never
+    calls datetime.now() — same convention archive.py uses for timestamps).
+    """
+    import migrate_state
+    from config_parser import parse_config
+
+    project_root = Path.cwd()
+    config_path = project_root / ".logfile-config.yml"
+    cfg = parse_config(str(config_path))
+    paths = cfg.get("paths", {})
+
+    state_path = project_root / paths.get("state", "logs/STATE.md")
+    devlog_path = project_root / paths.get("devlog", "logs/DEVLOG.md")
+
+    if not state_path.exists():
+        print(f"ERROR: STATE.md not found at {state_path}", file=sys.stderr)
+        return 2
+
+    state_content = migrate_state.read_text_normalized(state_path)
+    plan = migrate_state.build_plan(state_content, cfg)
+
+    # Stream the human-readable plan to stdout (UTF-8 bytes — matches cmd_archive).
+    sys.stdout.buffer.write(plan.to_human().encode("utf-8"))
+    sys.stdout.buffer.write(b"\n")
+
+    if args.dry_run:
+        return 0
+
+    if not args.force:
+        try:
+            reply = input("Apply this migration plan? [y/N] ").strip().lower()
+        except EOFError:
+            reply = ""
+        if reply not in ("y", "yes"):
+            print("Aborted.", file=sys.stderr)
+            return 1
+
+    from datetime import datetime
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    try:
+        migrate_state.apply(
+            plan,
+            state_path=state_path,
+            devlog_path=devlog_path,
+            today=today,
+            config_path=config_path,
+        )
+    except migrate_state.MigrateError as e:
+        # Guard trips (already-compliant/empty plan, or already-migrated) are
+        # no-ops, not failures: print a clear ASCII message and exit 0.
+        print(str(e).replace("—", "--"))
+        return 0
+
+    print(f"Applied STATE migration ({state_path.name} rewritten).")
+    return 0
+
+
 def cmd_install_hooks(args):
     """Install git pre-commit hooks"""
     import shutil
@@ -322,6 +521,8 @@ def main():
     p_validate = subparsers.add_parser('validate', help='Validate log files')
     p_validate.add_argument('--changelog', action='store_true', help='Only validate CHANGELOG')
     p_validate.add_argument('--devlog', action='store_true', help='Only validate DEVLOG')
+    p_validate.add_argument('--state-only', dest='state_only', action='store_true',
+                            help='Only validate STATE (non-zero exit iff STATE has errors)')
     p_validate.add_argument('--tokens', action='store_true', help='Only check token counts')
     p_validate.add_argument('--verbose', action='store_true', help='Verbose output')
     p_validate.add_argument('--json', action='store_true', help='JSON output')
@@ -389,6 +590,26 @@ def main():
     p_arch.add_argument('--adr', action='store_true',
                         help='(rejected) ADRs do not archive')
 
+    # migrate-state command
+    p_migrate = subparsers.add_parser(
+        'migrate-state',
+        help="Bring a brownfield STATE.md into the current spec (deterministic, previewable)")
+    p_migrate.add_argument('--dry-run', action='store_true',
+                           help='Show the plan but write nothing')
+    p_migrate.add_argument('--force', action='store_true',
+                           help='Skip the confirmation prompt')
+
+    # merge-agents-md command
+    p_merge = subparsers.add_parser(
+        'merge-agents-md',
+        help="Merge the canonical managed block into a target AGENTS.md (brownfield-safe)")
+    p_merge.add_argument('--to', required=True,
+                         help='Path to the target AGENTS.md (created if absent)')
+    p_merge.add_argument('--no-wrap', action='store_true',
+                         help='Prepend the block instead of wrapping pre-marker LFG content')
+    p_merge.add_argument('--force-downgrade', action='store_true',
+                         help='Overwrite a block managed by a newer LFG version')
+
     args = parser.parse_args()
 
     if not args.command:
@@ -408,6 +629,8 @@ def main():
         'prime': cmd_prime,
         'promote': cmd_promote,
         'archive': cmd_archive,
+        'migrate-state': cmd_migrate_state,
+        'merge-agents-md': cmd_merge_agents_md,
     }
 
     return handlers[args.command](args)

--- a/product/scripts/lint-logs.py
+++ b/product/scripts/lint-logs.py
@@ -445,7 +445,7 @@ class LogLinter:
         return result
 
     def validate_state(self) -> ValidationResult:
-        """Validate STATE.md exists and is within its token budget."""
+        """Validate STATE.md exists, is structurally sound, and within budget."""
         result = ValidationResult(file=self.state_path)
         if not os.path.exists(self.state_path):
             result.add_issue('warning', None, f"STATE not found at {self.state_path}",
@@ -453,6 +453,15 @@ class LogLinter:
             return result
         with open(self.state_path, 'r', encoding='utf-8') as f:
             text = f.read()
+        # Structural check (ERROR): the v0.3.0 STATE spec requires a
+        # `## Current Context` section. Its absence means STATE is malformed or
+        # predates the v0.3.0 layout and needs `lfg migrate-state`. This is the
+        # only STATE condition that should fail validation (exit 2); budget
+        # issues stay warnings (see below).
+        if not re.search(r'(?m)^##\s+Current Context\b', text):
+            result.add_issue('error', None,
+                             "STATE missing '## Current Context' section",
+                             "Run `lfg migrate-state` or add a '## Current Context' section")
         token_count = self._estimate_tokens(text)
         # WARNING not error: STATE has no archival (you trim it), and a freshly
         # installed template carries removable guidance that exceeds the budget.
@@ -602,6 +611,7 @@ def main():
     parser = argparse.ArgumentParser(description="Validate Log File Genius log files")
     parser.add_argument('--changelog', action='store_true', help="Validate only CHANGELOG")
     parser.add_argument('--devlog', action='store_true', help="Validate only DEVLOG")
+    parser.add_argument('--state', action='store_true', help="Validate only STATE")
     parser.add_argument('--strict', action='store_true', help="Fail on warnings")
     parser.add_argument('--json', action='store_true', help="Output as JSON")
     parser.add_argument('--config', default=".logfile-config.yml", help="Config file path")
@@ -634,6 +644,8 @@ def main():
         results = [linter.validate_changelog()]
     elif args.devlog:
         results = [linter.validate_devlog()]
+    elif args.state:
+        results = [linter.validate_state()]
     else:
         results = linter.run_all_validations()
 

--- a/product/scripts/migrate_state.py
+++ b/product/scripts/migrate_state.py
@@ -1,0 +1,498 @@
+"""Brownfield STATE.md migration to the v0.4.0 spec (Spec 4 §2).
+
+Plan/apply module mirroring archive.py's shape: pure-planning functions
+(`parse_state`, `build_plan`) build a `MigratePlan`; `apply(plan, ...)` does the
+I/O. No I/O in the planner — same testability pattern as archive.py / generator.
+
+v0.3.0's stricter STATE.md rules flag pre-existing content on first run after an
+upgrade, with no tool to bring it into compliance. `lfg migrate-state` is that
+tool: it keeps the canonical sections (truncating any that blow the budget),
+bundles non-canonical user content into a single one-time DEVLOG snapshot entry,
+and drops empty placeholders.
+
+The verb is a hard one-shot, guarded two ways (either trips refusal):
+  1. STATE.md already passes v0.3.0 validation cleanly (nothing to migrate).
+  2. DEVLOG.md already carries the snapshot entry (already migrated — re-running
+     after a user edits STATE back into non-compliance must NOT re-archive
+     sections that no longer exist).
+
+Encoding & atomicity policy (Spec 4 §1) is REUSED from agents_merge:
+read with utf-8-sig + LF normalization (`read_text_normalized`), write LF/UTF-8/
+no-BOM atomically (`atomic_write`). `apply` stages BOTH files to tmp, then renames
+DEVLOG first so STATE never lands without its snapshot — see `apply` for the exact
+ordering and failure behavior.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Sibling-module imports (archive.py pattern). Reuse the encoding/atomicity
+# helpers from agents_merge rather than re-implementing them.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Re-exported for the CLI layer (lfg.py calls migrate_state.read_text_normalized
+# / .atomic_write). Keep these even if this module's body doesn't reference one.
+from agents_merge import read_text_normalized, atomic_write
+
+
+# Default STATE token budget when config doesn't set token_targets.state.
+# Matches lint-logs.py (self.state_target default = 500).
+DEFAULT_STATE_TARGET = 500
+
+# The canonical v0.3.0 STATE sections to KEEP. Sourced from Spec 4 §2
+# ("keep: Current Context, Last Session, In Progress (the v0.3.0 spec)") and
+# corroborated by product/templates/STATE_template.md (Current Context / Last
+# Session). Matched case-insensitively against `## <heading>` lines; the
+# heading may carry a parenthetical suffix (e.g. "Current Context (Source of
+# Truth)").
+CANONICAL_SECTIONS = ("Current Context", "Last Session", "In Progress")
+
+# Heading text that is structurally part of the doc but not session content —
+# never archived, never dropped, always passed through verbatim in keep order.
+# "Related Documents" carries the frontmatter links the validator checks.
+STRUCTURAL_SECTIONS = ("Related Documents",)
+
+# The one-shot DEVLOG snapshot heading. The date is filled in by the caller.
+SNAPSHOT_TITLE = "STATE snapshot pre-v0.4.0 migration"
+# Guard-2 detector: matches the snapshot heading on its own line.
+SNAPSHOT_HEADING_RE = re.compile(
+    r"^### \d{4}-\d{2}-\d{2}: STATE snapshot pre-v0\.4\.0 migration$",
+    re.MULTILINE,
+)
+
+# A `## Heading` line (level-2 only — STATE sections are `##`).
+_SECTION_RE = re.compile(r"^##\s+(?P<title>.+?)\s*$")
+_DAILY_LOG_RE = re.compile(r"^##\s+Daily Log\b", re.IGNORECASE)
+
+
+class MigrateError(ValueError):
+    """Raised when migration cannot or should not proceed (mirrors ArchiveError)."""
+
+
+def _estimate_tokens(text: str) -> int:
+    """Match the canonical chars/4 heuristic (archive.py / lint-logs.py)."""
+    return len(text) // 4
+
+
+@dataclass
+class Section:
+    """One `## ...` section of STATE.md: heading line + body, with a token count.
+
+    `heading` is the canonical title text (without the leading `## `, e.g.
+    "Current Context"). `raw` is the full section as it appeared in the file
+    (heading line through to the next `##`), used verbatim when archiving.
+    """
+    heading: str
+    raw: str
+    tokens: int
+
+    def matches_canonical(self) -> Optional[str]:
+        """Return the canonical name this section maps to, or None.
+
+        Case-insensitive prefix match so "Current Context (Source of Truth)"
+        maps to "Current Context".
+        """
+        low = self.heading.lower()
+        for name in CANONICAL_SECTIONS:
+            if low == name.lower() or low.startswith(name.lower()):
+                return name
+        return None
+
+    def is_structural(self) -> bool:
+        low = self.heading.lower()
+        return any(low.startswith(name.lower()) for name in STRUCTURAL_SECTIONS)
+
+    def has_real_content(self) -> bool:
+        """True if the body holds something beyond placeholders/whitespace.
+
+        Placeholder markers from the templates ("*None*", "*No active work*",
+        bracketed "[fill me in]" stubs) count as empty.
+        """
+        body = self.raw
+        # Strip the heading line itself.
+        body = re.sub(r"^##\s+.*$", "", body, count=1, flags=re.MULTILINE)
+        # Remove horizontal-rule separators and bracketed placeholder stubs.
+        stripped = body.replace("---", "")
+        stripped = re.sub(r"\[[^\]]*\]", "", stripped)        # [placeholder]
+        stripped = re.sub(r"\*[^*]*\*", "", stripped)          # *None* / *No ...*
+        stripped = re.sub(r"[-*>#`:0-9.()\s]", "", stripped)   # list/quote/punct noise
+        return bool(stripped)
+
+
+@dataclass
+class MigratePlan:
+    """The result of build_plan; mirrors ArchivePlan (dry-run friendly)."""
+    keep: list[Section] = field(default_factory=list)
+    archive_to_devlog: list[Section] = field(default_factory=list)
+    drop: list[Section] = field(default_factory=list)
+    target_tokens: int = DEFAULT_STATE_TARGET
+    # Sections whose kept content was truncated to fit budget (heading -> note).
+    truncations: list[str] = field(default_factory=list)
+    # The frontmatter / preamble before the first `## ` heading (kept verbatim).
+    preamble: str = ""
+
+    def is_empty(self) -> bool:
+        return not self.archive_to_devlog and not self.drop and not self.truncations
+
+    def to_human(self) -> str:
+        """Human-readable dry-run summary (mirrors ArchivePlan.to_human)."""
+        out: list[str] = [f"STATE migration plan (target {self.target_tokens} tokens):"]
+        if self.keep:
+            out.append("KEEP:")
+            for s in self.keep:
+                out.append(f"  - {s.heading} (~{s.tokens} tokens)")
+        for note in self.truncations:
+            out.append(f"TRUNCATED: {note}")
+        if self.archive_to_devlog:
+            out.append("ARCHIVE TO DEVLOG (one snapshot entry):")
+            for s in self.archive_to_devlog:
+                out.append(f"  - {s.heading} (~{s.tokens} tokens)")
+        if self.drop:
+            out.append("DROP (empty/placeholder):")
+            for s in self.drop:
+                out.append(f"  - {s.heading}")
+        if self.is_empty():
+            out.append("  (nothing to change — STATE already conforms)")
+        return "\n".join(out)
+
+
+def parse_state(content: str) -> list[Section]:
+    """Split STATE.md into Sections by `##` headings.
+
+    Everything before the first `## ` heading (frontmatter, title, intro) is the
+    preamble and is NOT returned as a Section — callers that need it use
+    `split_preamble`. Each Section captures its heading text, the raw span from
+    its heading through to the next `##` (exclusive), and a token count.
+    """
+    _, sections = split_preamble(content)
+    return sections
+
+
+def split_preamble(content: str) -> tuple[str, list[Section]]:
+    """Return (preamble, sections). Preamble is text before the first `## `."""
+    lines = content.splitlines(keepends=True)
+    n = len(lines)
+
+    first = next((i for i, ln in enumerate(lines) if _SECTION_RE.match(ln)), None)
+    if first is None:
+        return content, []
+
+    preamble = "".join(lines[:first])
+
+    sections: list[Section] = []
+    i = first
+    while i < n:
+        m = _SECTION_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        start = i
+        end = next((j for j in range(i + 1, n) if _SECTION_RE.match(lines[j])), n)
+        raw = "".join(lines[start:end])
+        sections.append(
+            Section(heading=m.group("title").strip(), raw=raw, tokens=_estimate_tokens(raw))
+        )
+        i = end
+    return preamble, sections
+
+
+def _truncate_section(section: Section, max_tokens: int) -> tuple[Section, str]:
+    """Truncate a section's body to the most-recent content within max_tokens.
+
+    "Most-recent" = keep the heading + the LAST lines that fit, since STATE
+    sections list newest activity last (e.g. "Recently Completed" appends).
+    Returns (new_section, note). max_tokens includes the heading line.
+    """
+    lines = section.raw.splitlines(keepends=True)
+    heading_line = lines[0] if lines else f"## {section.heading}\n"
+    body_lines = lines[1:]
+
+    marker = "_(...older content truncated by `lfg migrate-state`...)_\n"
+    # Budget against the assembled string's token count (chars/4 of the whole),
+    # not a sum of per-line estimates — per-line integer division underestimates
+    # the concatenated total and would overshoot max_tokens. We reserve the
+    # heading + marker up front and grow the kept body newest-first.
+    fixed_prefix = heading_line + marker  # marker always present once truncated
+    kept_rev: list[str] = []
+    for ln in reversed(body_lines):
+        candidate = fixed_prefix + "".join(reversed(kept_rev + [ln]))
+        if _estimate_tokens(candidate) > max_tokens and kept_rev:
+            break
+        kept_rev.append(ln)
+    kept = list(reversed(kept_rev))
+
+    new_raw = heading_line
+    if len(kept) < len(body_lines):
+        new_raw += marker
+    new_raw += "".join(kept)
+
+    note = (
+        f"'{section.heading}' was {section.tokens} tokens (over budget); "
+        f"truncated to most-recent ~{_estimate_tokens(new_raw)} tokens."
+    )
+    return Section(heading=section.heading, raw=new_raw, tokens=_estimate_tokens(new_raw)), note
+
+
+def build_plan(state_content: str, config: dict) -> MigratePlan:
+    """Classify every STATE section into keep / archive_to_devlog / drop.
+
+    - keep: canonical v0.3.0 sections (Current Context, Last Session, In
+      Progress) and structural sections (Related Documents), in canonical
+      order. A kept section over the per-section budget is truncated to the
+      most-recent content and the truncation is recorded.
+    - archive_to_devlog: non-canonical sections that hold real user content;
+      bundled into ONE DEVLOG snapshot entry by `apply`.
+    - drop: empty/placeholder sections with no semantic value.
+
+    target_tokens comes from config token_targets.state (default 500).
+    """
+    targets = config.get("token_targets", {}) if config else {}
+    target_tokens = int(targets.get("state", DEFAULT_STATE_TARGET))
+
+    preamble, sections = split_preamble(state_content)
+    plan = MigratePlan(target_tokens=target_tokens, preamble=preamble)
+
+    # Per-section budget: a kept section shouldn't, on its own, exceed the whole
+    # STATE budget. Truncate any that does.
+    per_section_budget = target_tokens
+
+    canonical_found: dict[str, Section] = {}
+    structural_keep: list[Section] = []
+
+    for s in sections:
+        if s.is_structural():
+            structural_keep.append(s)
+            continue
+        canon = s.matches_canonical()
+        if canon is not None:
+            # First match wins per canonical name (defends against duplicates).
+            canonical_found.setdefault(canon, s)
+            continue
+        # Non-canonical: archive real content, drop placeholders.
+        if s.has_real_content():
+            plan.archive_to_devlog.append(s)
+        else:
+            plan.drop.append(s)
+
+    # Assemble keep in a stable, readable order: structural first, then
+    # canonical sections in CANONICAL_SECTIONS order. Apply truncation.
+    ordered_keep: list[Section] = list(structural_keep)
+    for name in CANONICAL_SECTIONS:
+        s = canonical_found.get(name)
+        if s is None:
+            continue
+        if s.tokens > per_section_budget:
+            s, note = _truncate_section(s, per_section_budget)
+            plan.truncations.append(note)
+        ordered_keep.append(s)
+    plan.keep = ordered_keep
+    return plan
+
+
+# ----- STATE / DEVLOG rendering -----
+
+def _render_state(plan: MigratePlan) -> str:
+    """Compose the new STATE.md from the plan's preamble + kept sections."""
+    parts: list[str] = []
+    pre = plan.preamble.rstrip("\n")
+    if pre:
+        parts.append(pre + "\n")
+    for s in plan.keep:
+        parts.append(s.raw.rstrip("\n") + "\n")
+    # Single blank line between blocks; trailing newline.
+    return "\n".join(p.rstrip("\n") for p in parts) + "\n"
+
+
+def _render_snapshot_entry(plan: MigratePlan, today: str) -> str:
+    """Render the one-time DEVLOG snapshot entry bundling archive_to_devlog.
+
+    Heading is EXACTLY `### <today>: STATE snapshot pre-v0.4.0 migration`.
+    """
+    lines = [f"### {today}: {SNAPSHOT_TITLE}", ""]
+    lines.append(
+        "Sections archived from STATE.md during the v0.4.0 migration "
+        "(non-canonical content preserved here for history):"
+    )
+    lines.append("")
+    for s in plan.archive_to_devlog:
+        lines.append(s.raw.rstrip("\n"))
+        lines.append("")
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def _insert_snapshot_at_end_of_daily_log(devlog: str, snapshot_entry: str) -> str:
+    """Insert snapshot_entry at the END of the `## Daily Log` section.
+
+    DEVLOG is newest-first; the snapshot is historical, so it goes at the bottom
+    of the Daily Log (oldest position), BEFORE any later `## ` section (e.g.
+    `## Archive`). Raises MigrateError if there is no `## Daily Log` heading.
+    """
+    lines = devlog.splitlines(keepends=True)
+    n = len(lines)
+
+    dl_idx = next((i for i, ln in enumerate(lines) if _DAILY_LOG_RE.match(ln)), None)
+    if dl_idx is None:
+        raise MigrateError("DEVLOG missing '## Daily Log' heading; cannot insert snapshot")
+
+    # End of the Daily Log section = next `## ` heading after it, or EOF.
+    end = next((j for j in range(dl_idx + 1, n) if lines[j].startswith("## ")), n)
+
+    before = "".join(lines[:end])
+    after = "".join(lines[end:])
+
+    block = before.rstrip("\n") + "\n\n" + snapshot_entry.rstrip("\n") + "\n"
+    if after:
+        block += "\n" + after.lstrip("\n")
+    return block
+
+
+# ----- apply -----
+
+def _state_is_compliant(state_path: Path, config_path: Path) -> bool:
+    """Guard 1: does STATE.md already pass v0.3.0 validation with no errors?
+
+    Reuses lint-logs.py's LogLinter.validate_state (loaded via importlib because
+    the module name is hyphenated). Errors-only semantics (matching the
+    `lfg validate --file STATE.md` granularity from T8): budget *warnings* do not
+    count as needing migration — only structural errors (missing Current Context)
+    do. So "compliant" == zero validation errors.
+    """
+    scripts_dir = Path(__file__).resolve().parent
+    spec = importlib.util.spec_from_file_location(
+        "_lfg_lint_logs", scripts_dir / "lint-logs.py"
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise MigrateError("could not load lint-logs.py for STATE validation")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    linter = module.LogLinter(config_path=str(config_path))
+    # Point the linter at the STATE file we're migrating.
+    linter.state_path = str(state_path)
+    result = linter.validate_state()
+    return result.errors == 0
+
+
+def apply(
+    plan: MigratePlan,
+    state_path: str | os.PathLike[str],
+    devlog_path: str | os.PathLike[str],
+    today: str,
+    config_path: Optional[str | os.PathLike[str]] = None,
+) -> None:
+    """Write the new STATE.md and append the snapshot to DEVLOG, atomically.
+
+    Guards (either trips refusal — hard one-shot):
+      1. STATE.md already passes v0.3.0 validation cleanly (errors == 0).
+      2. DEVLOG.md already contains the snapshot heading.
+
+    `today` is the YYYY-MM-DD date for the snapshot heading. Following
+    archive.py's convention, the pure planner never calls datetime.now(); the
+    date is supplied by the CLI layer and threaded through here.
+
+    Atomic two-file ordering & failure behavior:
+      1. Render both new contents in memory first (no writes yet).
+      2. Stage STATE -> <state>.lfg-tmp and DEVLOG -> <devlog>.lfg-tmp (both
+         written and fsynced; neither target touched yet).
+      3. os.replace(devlog.tmp, devlog) FIRST — the snapshot lands before STATE
+         is rewritten, so STATE is never left pointing at content whose archived
+         sections have no home.
+      4. os.replace(state.tmp, state) SECOND.
+      If step 3 fails: nothing has landed; both tmp files are cleaned up; STATE
+      is untouched. If step 4 fails AFTER step 3 succeeded: DEVLOG has the
+      snapshot (lossless — sections are preserved there) but STATE keeps its
+      original content. Re-running is then blocked by Guard 2, so the user
+      finishes the STATE rewrite by hand or restores DEVLOG — we never silently
+      lose the archived sections. We attempt to clean the leftover state tmp.
+    """
+    state_path = Path(state_path)
+    devlog_path = Path(devlog_path)
+    cfg_path = Path(config_path) if config_path else (state_path.parent.parent / ".logfile-config.yml")
+
+    # --- Guard 1: already compliant AND nothing to do.
+    #
+    # The validator (lint-logs.validate_state) only ERRORs on a missing
+    # `## Current Context` section; a STATE that still carries non-canonical
+    # sections to migrate passes it. So "passes validation" alone would refuse
+    # exactly the brownfield case this tool exists for. Per the spec's
+    # parenthetical ("already passes validation cleanly (nothing to do)"), we
+    # treat the operative condition as *nothing to do*: refuse only when the
+    # validator is clean AND the plan would make no change (no archive, no drop,
+    # no truncation). A non-empty plan always has work to do, so it proceeds.
+    if plan.is_empty() and _state_is_compliant(state_path, cfg_path):
+        raise MigrateError(
+            "STATE.md already passes v0.4.0 validation and the plan is empty — "
+            "nothing to migrate."
+        )
+
+    # --- Guard 2: DEVLOG already migrated.
+    devlog_text = read_text_normalized(devlog_path)
+    if SNAPSHOT_HEADING_RE.search(devlog_text):
+        raise MigrateError(
+            "DEVLOG.md already contains a 'STATE snapshot pre-v0.4.0 migration' "
+            "entry — migration is one-shot and has already run."
+        )
+
+    # --- Render both new contents up front (pure, no I/O).
+    new_state = _render_state(plan)
+    if plan.archive_to_devlog:
+        snapshot = _render_snapshot_entry(plan, today)
+        new_devlog = _insert_snapshot_at_end_of_daily_log(devlog_text, snapshot)
+    else:
+        # Nothing to archive: STATE-only migration (truncations/drops).
+        new_devlog = None
+
+    state_tmp = state_path.with_name(state_path.name + ".lfg-tmp")
+
+    if new_devlog is None:
+        # Single-file path: atomic_write already handles tmp+fsync+replace.
+        atomic_write(state_path, new_state)
+        return
+
+    devlog_tmp = devlog_path.with_name(devlog_path.name + ".lfg-tmp")
+
+    # Stage BOTH tmp files first (write + fsync); replace nothing yet.
+    _write_tmp(state_tmp, new_state)
+    try:
+        _write_tmp(devlog_tmp, new_devlog)
+    except BaseException:
+        _safe_unlink(state_tmp)
+        raise
+
+    # Commit: DEVLOG first (snapshot must land before STATE is rewritten).
+    try:
+        os.replace(devlog_tmp, devlog_path)
+    except BaseException:
+        # Nothing landed; clean up both tmp files; STATE untouched.
+        _safe_unlink(devlog_tmp)
+        _safe_unlink(state_tmp)
+        raise
+
+    # DEVLOG committed. Now commit STATE.
+    try:
+        os.replace(state_tmp, state_path)
+    except BaseException:
+        # DEVLOG already has the snapshot (lossless); STATE keeps its original.
+        # Guard 2 will block a re-run. Clean the leftover STATE tmp and surface.
+        _safe_unlink(state_tmp)
+        raise
+
+
+def _write_tmp(tmp: Path, content: str) -> None:
+    """Write content to tmp as UTF-8/LF/no-BOM with fsync (no replace)."""
+    with open(tmp, "w", encoding="utf-8", newline="\n") as f:
+        f.write(content)
+        f.flush()
+        os.fsync(f.fileno())
+
+
+def _safe_unlink(path: Path) -> None:
+    try:
+        path.unlink()
+    except OSError:
+        pass

--- a/product/scripts/update.ps1
+++ b/product/scripts/update.ps1
@@ -253,17 +253,33 @@ if ($AiAssistant -ne "unknown") {
     }
 }
 
-$agentsSrc = Join-Path $SourceRoot "product\AGENTS.md"
-if (Test-Path $agentsSrc) {
-    $agentsText = (Get-Content $agentsSrc -Raw) -replace "`r`n", "`n"
-    $tmp = [System.IO.Path]::GetTempFileName()
-    [System.IO.File]::WriteAllText($tmp, $agentsText, (New-Object System.Text.UTF8Encoding $false))
-    $dest = Join-Path $ProjectRoot "AGENTS.md"
-    if (Prompt-Update "AGENTS.md" $tmp $dest) {
-        [System.IO.File]::WriteAllText($dest, $agentsText, (New-Object System.Text.UTF8Encoding $false))
-        Print-Success "Updated: AGENTS.md"
+# Update AGENTS.md at project root via the managed-block merge (Spec 4 §1).
+# REPLACES the old prompt-then-overwrite (a "y" there fully overwrote the file
+# = data loss). The merge preserves user content, only rewrites the LFG block,
+# and is idempotent. The merge entrypoint owns read, merge, and atomic write.
+$LfgPy = Join-Path $SourceRoot "product\scripts\lfg.py"
+$PythonBin = $null
+if (Get-Command python -ErrorAction SilentlyContinue) {
+    $PythonBin = "python"
+} elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+    $PythonBin = "python3"
+}
+
+$agentsDest = Join-Path $ProjectRoot "AGENTS.md"
+if (-not $PythonBin) {
+    # No merge possible without Python. NEVER fall back to overwriting.
+    Print-Warning "Python not found; skipping AGENTS.md update (merge requires Python)."
+} elseif (-not (Test-Path $LfgPy)) {
+    Print-Warning "lfg.py not found at $LfgPy; skipping AGENTS.md update."
+} else {
+    Print-Info "Merging AGENTS.md (preserves your content, refreshes the LFG block)"
+    # Surface the CLI's own output; on non-zero exit warn but keep going.
+    & $PythonBin $LfgPy merge-agents-md --to $agentsDest
+    if ($LASTEXITCODE -eq 0) {
+        Print-Success "AGENTS.md merge complete"
+    } else {
+        Print-Warning "AGENTS.md merge reported a problem (see above); continuing update."
     }
-    Remove-Item -Path $tmp -Force -ErrorAction SilentlyContinue
 }
 
 # Migrate legacy DEVLOG context into STATE.md for existing installs
@@ -293,26 +309,46 @@ if (Prompt-Update "validate-log-files.ps1" $ps1Script $ps1Dest) {
     Print-Success "Updated: validate-log-files.ps1"
 }
 
-# Update templates (careful - users may have customized these)
-Print-Info "Checking templates..."
-Print-Warning "Note: Templates are often customized. Review changes carefully."
-Write-Host ""
-
-$templatesPath = Join-Path $SourceRoot "product\templates"
-if (Test-Path $templatesPath) {
-    Get-ChildItem -Path $templatesPath -Filter "*.md" | ForEach-Object {
-        $templateName = $_.Name
-        $srcTemplate = $_.FullName
-        $destTemplate = Join-Path $ProjectRoot "templates\$templateName"
-        
-        if (Prompt-Update "Template: $templateName" $srcTemplate $destTemplate) {
-            $destDir = Split-Path -Parent $destTemplate
-            if (-not (Test-Path $destDir)) {
-                New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+# Templates are NOT copied to a project-root templates\ dir (Spec 4 §3).
+# They live only in .log-file-genius\product\templates\ (the submodule).
+# A root templates\ left over from older versions (LFG-installed) is moved
+# to backups; a user-authored templates\ is left untouched. We ONLY ever
+# inspect "$ProjectRoot\templates" here — never the user's root
+# .logfile-config.yml or anything outside that subdir.
+$rootTemplates = Join-Path $ProjectRoot "templates"
+if (Test-Path $rootTemplates -PathType Container) {
+    $matchHelper = Join-Path $SourceRoot "product\scripts\update_template_hashes.py"
+    if (-not $PythonBin) {
+        Print-Warning "Python not found; leaving root templates\ untouched (cannot verify hashes)."
+    } elseif (-not (Test-Path $matchHelper)) {
+        Print-Warning "Template hash helper not found; leaving root templates\ untouched."
+    } else {
+        # --match-dir exit 0 => >=1 file matches an LFG-shipped hash (any version).
+        & $PythonBin $matchHelper --match-dir $rootTemplates | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            $unixTime = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+            $backupsRoot = Join-Path $ProjectRoot ".log-file-genius\.backups"
+            $backupDir = Join-Path $backupsRoot "templates-$unixTime"
+            if (-not (Test-Path $backupsRoot)) {
+                New-Item -ItemType Directory -Path $backupsRoot -Force | Out-Null
             }
-            Copy-Item -Path $srcTemplate -Destination $destTemplate -Force
-            Print-Success "Updated: $templateName"
+            $nFiles = (Get-ChildItem -Path $rootTemplates -Recurse -File | Measure-Object).Count
+            Move-Item -Path $rootTemplates -Destination $backupDir -Force
+            Print-Success "Moved $nFiles LFG-installed templates to $backupDir (they now live in .log-file-genius\product\templates\)."
+        } else {
+            Print-Info "Kept your templates\ (not LFG-installed)."
         }
+    }
+}
+
+# Post-update STATE.md advisory (Spec 4 §2). Run `lfg validate --state-only`;
+# if STATE.md has errors (non-zero exit), print ONE advisory line pointing at
+# the migrate-state dry-run. We never auto-run or prompt — update stays
+# non-interactive. If Python is unavailable, skip silently (no advisory).
+if ($PythonBin -and (Test-Path $LfgPy)) {
+    & $PythonBin $LfgPy validate --state-only > $null 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Print-Warning "STATE.md needs migration to the current spec. Preview with: $PythonBin $LfgPy migrate-state --dry-run"
     }
 }
 

--- a/product/scripts/update.sh
+++ b/product/scripts/update.sh
@@ -237,16 +237,32 @@ if [ "$AI_ASSISTANT" != "unknown" ]; then
     fi
 fi
 
-# Update AGENTS.md at project root (strip CRLF as in install).
-AGENTS_SRC="$SOURCE_ROOT/product/AGENTS.md"
-if [ -f "$AGENTS_SRC" ]; then
-    AGENTS_TMP=$(mktemp)
-    tr -d '\r' < "$AGENTS_SRC" > "$AGENTS_TMP"
-    if prompt_update "AGENTS.md" "$AGENTS_TMP" "$PROJECT_ROOT/AGENTS.md"; then
-        cp "$AGENTS_TMP" "$PROJECT_ROOT/AGENTS.md"
-        print_success "Updated: AGENTS.md"
+# Update AGENTS.md at project root via the managed-block merge (Spec 4 §1).
+# This REPLACES the old prompt-then-overwrite: a "y" there fully overwrote the
+# file (data loss). The merge is strictly safer — it preserves user content,
+# only rewrites the LFG block, and is idempotent (no-op on a re-run). The
+# merge entrypoint owns read, merge, and atomic write.
+LFG_PY="$SOURCE_ROOT/product/scripts/lfg.py"
+PYTHON_BIN=""
+if command -v python3 > /dev/null 2>&1; then
+    PYTHON_BIN="python3"
+elif command -v python > /dev/null 2>&1; then
+    PYTHON_BIN="python"
+fi
+
+if [ -z "$PYTHON_BIN" ]; then
+    # No merge possible without Python. NEVER fall back to overwriting.
+    print_warning "Python not found; skipping AGENTS.md update (merge requires Python)."
+elif [ ! -f "$LFG_PY" ]; then
+    print_warning "lfg.py not found at $LFG_PY; skipping AGENTS.md update."
+else
+    print_info "Merging AGENTS.md (preserves your content, refreshes the LFG block)"
+    # Surface the CLI's own output; on non-zero exit warn but keep going.
+    if "$PYTHON_BIN" "$LFG_PY" merge-agents-md --to "$PROJECT_ROOT/AGENTS.md"; then
+        print_success "AGENTS.md merge complete"
+    else
+        print_warning "AGENTS.md merge reported a problem (see above); continuing update."
     fi
-    rm -f "$AGENTS_TMP"
 fi
 
 # Migrate legacy DEVLOG context into STATE.md for existing installs
@@ -269,23 +285,43 @@ if prompt_update "validate-log-files.ps1" \
     print_success "Updated: validate-log-files.ps1"
 fi
 
-# Update templates (careful - users may have customized these)
-print_info "Checking templates..."
-print_warning "Note: Templates are often customized. Review changes carefully."
-echo ""
-
-for template in "$SOURCE_ROOT/product/templates/"*.md; do
-    if [[ -f "$template" ]]; then
-        template_name=$(basename "$template")
-        dest_template="$PROJECT_ROOT/templates/$template_name"
-        
-        if prompt_update "Template: $template_name" "$template" "$dest_template"; then
-            mkdir -p "$PROJECT_ROOT/templates"
-            cp "$template" "$dest_template"
-            print_success "Updated: $template_name"
+# Templates are NOT copied to a project-root templates/ dir (Spec 4 §3).
+# They live only in .log-file-genius/product/templates/ (the submodule).
+# A root templates/ left over from older versions (LFG-installed) is moved
+# to backups; a user-authored templates/ is left untouched. We ONLY ever
+# inspect "$PROJECT_ROOT/templates" here — never the user's root
+# .logfile-config.yml or anything outside that subdir.
+ROOT_TEMPLATES="$PROJECT_ROOT/templates"
+if [ -d "$ROOT_TEMPLATES" ]; then
+    MATCH_HELPER="$SOURCE_ROOT/product/scripts/update_template_hashes.py"
+    if [ -z "$PYTHON_BIN" ]; then
+        print_warning "Python not found; leaving root templates/ untouched (cannot verify hashes)."
+    elif [ ! -f "$MATCH_HELPER" ]; then
+        print_warning "Template hash helper not found; leaving root templates/ untouched."
+    else
+        # --match-dir exit 0 => >=1 file matches an LFG-shipped hash (any version).
+        if "$PYTHON_BIN" "$MATCH_HELPER" --match-dir "$ROOT_TEMPLATES" > /dev/null 2>&1; then
+            BACKUP_DIR="$PROJECT_ROOT/.log-file-genius/.backups/templates-$(date +%s)"
+            mkdir -p "$(dirname "$BACKUP_DIR")"
+            # Count files before the move for the message.
+            N_FILES=$(find "$ROOT_TEMPLATES" -type f | wc -l | tr -d ' ')
+            mv "$ROOT_TEMPLATES" "$BACKUP_DIR"
+            print_success "Moved $N_FILES LFG-installed templates to $BACKUP_DIR (they now live in .log-file-genius/product/templates/)."
+        else
+            print_info "Kept your templates/ (not LFG-installed)."
         fi
     fi
-done
+fi
+
+# Post-update STATE.md advisory (Spec 4 §2). Run `lfg validate --state-only`;
+# if STATE.md has errors (non-zero exit), print ONE advisory line pointing at
+# the migrate-state dry-run. We never auto-run or prompt — update stays
+# non-interactive. If Python is unavailable, skip silently (no advisory).
+if [ -n "$PYTHON_BIN" ] && [ -f "$LFG_PY" ]; then
+    if ! "$PYTHON_BIN" "$LFG_PY" validate --state-only > /dev/null 2>&1; then
+        print_warning "STATE.md needs migration to the current spec. Preview with: $PYTHON_BIN $LFG_PY migrate-state --dry-run"
+    fi
+fi
 
 echo ""
 echo -e "${GREEN}===========================================${NC}"

--- a/product/scripts/update_template_hashes.py
+++ b/product/scripts/update_template_hashes.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Build / verify the SHA-256 manifest of LFG-shipped templates.
+
+Spec 4 §3. The manifest (`known_template_hashes.json`) is the source of
+truth `update.{sh,ps1}` will use (in a LATER task, T7) to tell a user's
+LFG-installed root `templates/` files apart from their own hand-authored
+ones, so cleanup only ever moves files LFG actually shipped.
+
+Shape of the JSON — a top-level object keyed by LFG version, each value a
+map of forward-slash relative filename to lowercase SHA-256 hex digest::
+
+    {
+      "0.3.0": {
+        "ADR_template.md": "<sha256hex>",
+        "CHANGELOG_template.md": "<sha256hex>",
+        ...
+      },
+      "0.4.0": { ... }
+    }
+
+The manifest accumulates entries across versions: regenerating for a new
+version MERGES the new entry in and preserves all prior-version entries.
+
+Usage:
+    python update_template_hashes.py            # write/update for current version
+    python update_template_hashes.py --check    # CI gate: exit non-zero on drift
+    python update_template_hashes.py --match-dir <dir>  # report LFG-shipped files in <dir>
+
+Stdlib only; Python 3.11+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+# product/scripts/update_template_hashes.py -> product/
+_PRODUCT_ROOT = Path(__file__).resolve().parents[1]
+_TEMPLATES_DIR = _PRODUCT_ROOT / "templates"
+_VERSION_FILE = _PRODUCT_ROOT / "VERSION.json"
+_MANIFEST_FILE = _PRODUCT_ROOT / "scripts" / "known_template_hashes.json"
+
+_CHUNK = 65536
+
+
+def read_current_version(version_file: Path = _VERSION_FILE) -> str:
+    """Return the top-level ``version`` string from VERSION.json."""
+    try:
+        data = json.loads(version_file.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"VERSION.json not found at {version_file}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"VERSION.json is not valid JSON: {exc}") from exc
+
+    version = data.get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError(f"VERSION.json has no usable 'version' string: {version!r}")
+    return version.strip()
+
+
+def sha256_of_file(path: Path) -> str:
+    """Return the lowercase hex SHA-256 of a file's raw bytes."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def hash_templates(templates_dir: Path = _TEMPLATES_DIR) -> dict[str, str]:
+    """Hash every file under ``templates_dir``.
+
+    Keys are POSIX-style (forward-slash) paths relative to the templates
+    directory, so the manifest is byte-identical on Windows and Linux.
+    """
+    if not templates_dir.is_dir():
+        raise FileNotFoundError(f"templates directory not found: {templates_dir}")
+
+    hashes: dict[str, str] = {}
+    for path in sorted(templates_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(templates_dir).as_posix()
+        hashes[rel] = sha256_of_file(path)
+
+    if not hashes:
+        raise FileNotFoundError(f"no template files found under {templates_dir}")
+    return hashes
+
+
+def load_manifest(manifest_file: Path = _MANIFEST_FILE) -> dict[str, dict[str, str]]:
+    """Load the existing manifest, or return an empty mapping if absent."""
+    if not manifest_file.exists():
+        return {}
+    try:
+        data = json.loads(manifest_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"manifest is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("manifest top-level value must be an object keyed by version")
+    return data
+
+
+def write_manifest(
+    manifest: dict[str, dict[str, str]], manifest_file: Path = _MANIFEST_FILE
+) -> None:
+    """Write the manifest as sorted, newline-terminated UTF-8 JSON (LF)."""
+    text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    with manifest_file.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(text)
+
+
+def update_manifest() -> tuple[str, int]:
+    """Merge the current version's template hashes into the manifest.
+
+    Preserves all prior-version entries. Returns ``(version, file_count)``.
+    """
+    version = read_current_version()
+    current = hash_templates()
+    manifest = load_manifest()
+    manifest[version] = current
+    write_manifest(manifest)
+    return version, len(current)
+
+
+def check_manifest() -> int:
+    """CI gate: verify the on-disk templates match the current-version entry.
+
+    Returns 0 on match, 1 on any drift (missing entry, missing/extra files,
+    or changed hashes). Prints a human-readable diff to stderr on failure.
+    """
+    version = read_current_version()
+    on_disk = hash_templates()
+    manifest = load_manifest()
+
+    recorded = manifest.get(version)
+    if recorded is None:
+        print(
+            f"manifest has no entry for current version {version!r}; "
+            f"run: python {Path(__file__).name}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if recorded == on_disk:
+        return 0
+
+    on_disk_keys = set(on_disk)
+    recorded_keys = set(recorded)
+    for missing in sorted(recorded_keys - on_disk_keys):
+        print(f"  in manifest but missing on disk: {missing}", file=sys.stderr)
+    for extra in sorted(on_disk_keys - recorded_keys):
+        print(f"  on disk but missing from manifest: {extra}", file=sys.stderr)
+    for name in sorted(on_disk_keys & recorded_keys):
+        if on_disk[name] != recorded[name]:
+            print(f"  hash mismatch: {name}", file=sys.stderr)
+
+    print(
+        f"template hashes for {version!r} are out of date; "
+        f"regenerate with: python {Path(__file__).name}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def known_hashes(manifest: dict[str, dict[str, str]]) -> set[str]:
+    """Flatten the manifest into the set of every hash any version shipped.
+
+    A file in a project's root ``templates/`` counts as LFG-installed if its
+    SHA-256 matches a template LFG shipped in ANY version — so we union all
+    per-version digests rather than keying on filename or version.
+    """
+    digests: set[str] = set()
+    for version_entry in manifest.values():
+        if isinstance(version_entry, dict):
+            digests.update(version_entry.values())
+    return digests
+
+
+def match_dir(target_dir: Path, manifest_file: Path = _MANIFEST_FILE) -> int:
+    """Report which files under ``target_dir`` match any LFG-shipped hash.
+
+    Hashes every file under ``target_dir`` (recursively) and compares each
+    digest against the union of all hashes in the manifest. Prints one line
+    per matching file (``MATCH <relpath>``) to stdout, then a summary line
+    (``matched N of M file(s)``).
+
+    Exit codes (so a shell caller can branch without parsing text):
+      0 — at least one file matched (the dir holds LFG-installed templates).
+      1 — the directory has files but NONE matched (user-authored).
+      2 — error (dir missing / not a dir / manifest unreadable / dir empty).
+    """
+    if not target_dir.is_dir():
+        print(f"not a directory: {target_dir}", file=sys.stderr)
+        return 2
+
+    try:
+        manifest = load_manifest(manifest_file)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    shipped = known_hashes(manifest)
+
+    files = sorted(p for p in target_dir.rglob("*") if p.is_file())
+    if not files:
+        print(f"no files under {target_dir}", file=sys.stderr)
+        return 2
+
+    matched = 0
+    for path in files:
+        rel = path.relative_to(target_dir).as_posix()
+        if sha256_of_file(path) in shipped:
+            print(f"MATCH {rel}")
+            matched += 1
+
+    print(f"matched {matched} of {len(files)} file(s)")
+    return 0 if matched > 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the manifest matches on-disk templates; exit non-zero on drift",
+    )
+    parser.add_argument(
+        "--match-dir",
+        metavar="DIR",
+        help="report which files in DIR match any LFG-shipped template hash",
+    )
+    args = parser.parse_args(argv)
+
+    if args.match_dir:
+        return match_dir(Path(args.match_dir))
+
+    if args.check:
+        return check_manifest()
+
+    version, count = update_manifest()
+    print(f"wrote {count} template hash(es) for version {version} to {_MANIFEST_FILE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/product/scripts/validate-log-files.ps1
+++ b/product/scripts/validate-log-files.ps1
@@ -214,12 +214,51 @@ function Load-ProfileConfig {
     # Extract version and check for updates
     if ($cfg -match 'log_file_genius_version:\s*"?([0-9.]+)"?') {
         $configVersion = $matches[1]
-        $latestVersion = "0.2.0"  # Current version
 
-        if ($configVersion -ne $latestVersion) {
+        # Resolve the latest-known version from VERSION.json (this script lives
+        # in product/scripts/, the manifest in product/). Fall back to a
+        # hardcoded current version if the manifest can't be read.
+        $scriptDir = Split-Path -Parent $PSCommandPath
+        $versionFile = Join-Path $scriptDir "..\VERSION.json"
+        $latestVersion = "0.3.0"  # Fallback if VERSION.json is unreadable
+        if (Test-Path $versionFile) {
+            try {
+                $manifest = Get-Content $versionFile -Raw | ConvertFrom-Json
+                if ($manifest.version) { $latestVersion = $manifest.version }
+            } catch { }
+        }
+
+        # Three-way comparison (ahead / behind / current). Delegate to the
+        # Python comparator (single source of truth, handles pre-release +
+        # build metadata); fall back to a plain string compare if python is
+        # unavailable.
+        $relation = ""
+        $checkScript = Join-Path $scriptDir "check-version.py"
+        $python = $null
+        if (Get-Command python -ErrorAction SilentlyContinue) { $python = "python" }
+        elseif (Get-Command python3 -ErrorAction SilentlyContinue) { $python = "python3" }
+        if ($python -and (Test-Path $checkScript)) {
+            try {
+                $relation = (& $python $checkScript --compare $configVersion $latestVersion 2>$null).Trim()
+            } catch { $relation = "" }
+        }
+        if (-not $relation) {
+            # Python unavailable: we can only safely confirm equality with a
+            # plain string compare. We must NOT guess a direction — printing
+            # "behind" for an unequal pair would resurrect the reversed
+            # "update available" bug (Spec 4 T2) whenever the user is AHEAD.
+            # So: equal -> current; unequal but undeterminable -> stay silent.
+            if ($configVersion -eq $latestVersion) { $relation = "current" } else { $relation = "unknown" }
+        }
+
+        if ($relation -eq "behind") {
             Write-Host ""
             Write-Host "[!] Log File Genius update available: v$latestVersion (you have v$configVersion)" -ForegroundColor Yellow
             Write-Host "    See: https://github.com/clark-mackey/log-file-genius/releases" -ForegroundColor Yellow
+            Write-Host ""
+        } elseif ($relation -eq "ahead") {
+            Write-Host ""
+            Write-Host "[i] Log File Genius: you are on v$configVersion, newer than the latest-known v$latestVersion." -ForegroundColor Cyan
             Write-Host ""
         }
     }

--- a/product/scripts/validate-log-files.sh
+++ b/product/scripts/validate-log-files.sh
@@ -189,12 +189,48 @@ load_profile_config() {
     # Extract version and check for updates
     if grep -q "log_file_genius_version:" "$config_file"; then
         local config_version=$(grep "log_file_genius_version:" "$config_file" | sed 's/.*"\([0-9.]*\)".*/\1/')
-        local latest_version="0.2.0"  # Current version
 
-        if [ "$config_version" != "$latest_version" ]; then
+        # Resolve the latest-known version from VERSION.json (this script lives
+        # in product/scripts/, the manifest in product/). Fall back to a
+        # hardcoded current version if the manifest can't be read.
+        local script_dir
+        script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+        local version_file="$script_dir/../VERSION.json"
+        local latest_version="0.3.0"  # Fallback if VERSION.json is unreadable
+        if [ -f "$version_file" ]; then
+            local parsed
+            parsed=$(grep '"version"' "$version_file" | head -1 | sed 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+            [ -n "$parsed" ] && latest_version="$parsed"
+        fi
+
+        # Three-way comparison (ahead / behind / current). Delegate to the
+        # Python comparator (single source of truth, handles pre-release +
+        # build metadata); fall back to a plain string compare if python is
+        # unavailable.
+        local relation=""
+        local check_script="$script_dir/check-version.py"
+        if [ -f "$check_script" ] && command -v python3 >/dev/null 2>&1; then
+            relation=$(python3 "$check_script" --compare "$config_version" "$latest_version" 2>/dev/null)
+        elif [ -f "$check_script" ] && command -v python >/dev/null 2>&1; then
+            relation=$(python "$check_script" --compare "$config_version" "$latest_version" 2>/dev/null)
+        fi
+        if [ -z "$relation" ]; then
+            # Python unavailable: we can only safely confirm equality with a
+            # plain string compare. We must NOT guess a direction — printing
+            # "behind" for an unequal pair would resurrect the reversed
+            # "update available" bug (Spec 4 T2) whenever the user is AHEAD.
+            # So: equal -> current; unequal but undeterminable -> stay silent.
+            if [ "$config_version" = "$latest_version" ]; then relation="current"; else relation="unknown"; fi
+        fi
+
+        if [ "$relation" = "behind" ]; then
             echo ""
             echo -e "\033[33m[!] Log File Genius update available: v$latest_version (you have v$config_version)\033[0m"
             echo -e "\033[33m    See: https://github.com/clark-mackey/log-file-genius/releases\033[0m"
+            echo ""
+        elif [ "$relation" = "ahead" ]; then
+            echo ""
+            echo -e "\033[36m[i] Log File Genius: you are on v$config_version, newer than the latest-known v$latest_version.\033[0m"
             echo ""
         fi
     fi

--- a/product/tests/smoke_install.ps1
+++ b/product/tests/smoke_install.ps1
@@ -55,18 +55,42 @@ try {
         throw "FAIL: CHANGELOG.md missing frontmatter (first line is '$firstLine')"
     }
 
-    # Spec 2: AGENTS.md at project root with frontmatter.
+    # Spec 2: AGENTS.md at project root.
     if (-not (Test-Path "AGENTS.md")) { Write-Host "FAIL: AGENTS.md missing at project root"; exit 1 }
-    $firstLine = (Get-Content "AGENTS.md" -TotalCount 1)
-    if ($firstLine -ne "---") { Write-Host "FAIL: AGENTS.md missing frontmatter"; exit 1 }
 
-    # Spec 2: AGENTS.md must be LF + no BOM.
+    # Spec 4 §1: AGENTS.md is now a managed BLOCK. A fresh install wraps the
+    # canonical body in LFG:BEGIN/END markers, so the file starts with the
+    # BEGIN marker; the YAML frontmatter is INSIDE the block.
+    $agentsText = [System.IO.File]::ReadAllText("$pwd\AGENTS.md")
+    if ($agentsText -notmatch '<!-- LFG:BEGIN v') { Write-Host "FAIL: AGENTS.md missing LFG:BEGIN marker"; exit 1 }
+    if ($agentsText -notmatch '<!-- LFG:END -->') { Write-Host "FAIL: AGENTS.md missing LFG:END marker"; exit 1 }
+    if ($agentsText -notmatch '(?m)^doc: AGENTS$') { Write-Host "FAIL: AGENTS.md missing canonical body (doc: AGENTS)"; exit 1 }
+
+    # Spec 4 §3: NO root templates/ dir is created.
+    if (Test-Path "templates" -PathType Container) { Write-Host "FAIL: install created a root templates/ dir (Spec 4 §3 regression)"; exit 1 }
+
+    # Spec 2 / Spec 4: AGENTS.md must be UTF-8 with NO BOM and LF endings.
+    # Assert by reading raw bytes: first 3 bytes != EF BB BF, and no 0x0D (CR).
     $bytes = [System.IO.File]::ReadAllBytes("$pwd\AGENTS.md")
-    if ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
         Write-Host "FAIL: AGENTS.md has UTF-8 BOM"; exit 1
     }
-    $text = [System.IO.File]::ReadAllText("$pwd\AGENTS.md")
-    if ($text.Contains("`r`n")) { Write-Host "FAIL: AGENTS.md has CRLF line endings"; exit 1 }
+    if ($bytes -contains 0x0D) { Write-Host "FAIL: AGENTS.md has CR (0x0D) bytes - CRLF line endings"; exit 1 }
+
+    # Spec 4 §1: idempotent install — re-running the merge leaves AGENTS.md
+    # byte-identical (merge short-circuits on an up-to-date file).
+    $before = [System.IO.File]::ReadAllBytes("$pwd\AGENTS.md")
+    $py = $null
+    if (Get-Command python -ErrorAction SilentlyContinue) { $py = "python" }
+    elseif (Get-Command python3 -ErrorAction SilentlyContinue) { $py = "python3" }
+    if ($py) {
+        $mergeOut = & $py "$REPO\product\scripts\lfg.py" merge-agents-md --to "$pwd\AGENTS.md" 2>&1 | Out-String
+        if ($mergeOut -notmatch 'up to date') { Write-Host "FAIL: second merge did not report up-to-date: $mergeOut"; exit 1 }
+        $after = [System.IO.File]::ReadAllBytes("$pwd\AGENTS.md")
+        if (-not ([System.Linq.Enumerable]::SequenceEqual($before, $after))) {
+            Write-Host "FAIL: second merge changed AGENTS.md (not idempotent)"; exit 1
+        }
+    }
 
     # Spec 2: installed rule == canonical fragment.
     $installed = (Get-FileHash ".claude\rules\log-file-maintenance.md").Hash

--- a/product/tests/smoke_install.sh
+++ b/product/tests/smoke_install.sh
@@ -35,11 +35,37 @@ head -1 logs/CHANGELOG.md | grep -q '^---$' || { echo "FAIL: CHANGELOG.md missin
 
 # Spec 2: AGENTS.md must land at project root.
 test -f AGENTS.md || { echo "FAIL: AGENTS.md missing at project root"; exit 1; }
-head -1 AGENTS.md | grep -q '^---$' || { echo "FAIL: AGENTS.md missing frontmatter"; exit 1; }
+
+# Spec 4 §1: AGENTS.md is now a managed BLOCK. A fresh install wraps the
+# canonical body in LFG:BEGIN/END markers, so the file no longer starts with
+# the YAML frontmatter '---' — the BEGIN marker comes first, frontmatter is
+# inside the block.
+grep -q '<!-- LFG:BEGIN v' AGENTS.md || { echo "FAIL: AGENTS.md missing LFG:BEGIN marker"; exit 1; }
+grep -q '<!-- LFG:END -->' AGENTS.md || { echo "FAIL: AGENTS.md missing LFG:END marker"; exit 1; }
+# The canonical body (frontmatter + guidance) lives inside the block.
+grep -q '^doc: AGENTS$' AGENTS.md || { echo "FAIL: AGENTS.md missing canonical body (doc: AGENTS)"; exit 1; }
+
+# Spec 4 §3: NO root templates/ dir is created. Templates live only in
+# .log-file-genius/product/templates/. Only logs/ gets template-derived files.
+test -d templates && { echo "FAIL: install created a root templates/ dir (Spec 4 §3 regression)"; exit 1; } || true
 
 # Spec 2: AGENTS.md must be LF + no BOM (generator's documented contract).
 if grep -q $'\r' AGENTS.md; then echo "FAIL: AGENTS.md has CRLF line endings"; exit 1; fi
 head -c 3 AGENTS.md | grep -q $'\xEF\xBB\xBF' && { echo "FAIL: AGENTS.md has UTF-8 BOM"; exit 1; } || true
+
+# Spec 4 §1: idempotent install — re-running the merge leaves AGENTS.md
+# byte-identical (the merge short-circuits on an up-to-date file). We invoke
+# the same entrypoint install.sh uses rather than re-running the whole script.
+AGENTS_BEFORE_HASH="$(cksum < AGENTS.md)"
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then PYTHON_BIN="python3";
+elif command -v python >/dev/null 2>&1; then PYTHON_BIN="python"; fi
+if [ -n "$PYTHON_BIN" ]; then
+    MERGE_OUT="$("$PYTHON_BIN" "$REPO/product/scripts/lfg.py" merge-agents-md --to "$TMP/AGENTS.md" 2>&1)"
+    echo "$MERGE_OUT" | grep -qi 'up to date' || { echo "FAIL: second merge did not report up-to-date: $MERGE_OUT"; exit 1; }
+    AGENTS_AFTER_HASH="$(cksum < AGENTS.md)"
+    [ "$AGENTS_BEFORE_HASH" = "$AGENTS_AFTER_HASH" ] || { echo "FAIL: second merge changed AGENTS.md (not idempotent)"; exit 1; }
+fi
 
 # Spec 2: installed rule must equal the canonical fragment.
 diff -q .claude/rules/log-file-maintenance.md \

--- a/product/tests/smoke_update.ps1
+++ b/product/tests/smoke_update.ps1
@@ -1,0 +1,156 @@
+# product/tests/smoke_update.ps1
+# Cross-platform UPDATE smoke test (PowerShell) — Spec 4 brownfield-safe update.
+#
+# The full update.ps1 needs a real .log-file-genius/ git submodule + `git fetch`,
+# which is too heavy for a smoke test. We exercise the SPECIFIC new behaviors
+# update.ps1 performs, via the same entrypoints:
+#   - AGENTS.md merge:      lfg.py merge-agents-md --to <path>            (Spec 4 §1)
+#   - root templates/ move: update_template_hashes.py --match-dir + the
+#                           backup-move logic from update.ps1            (Spec 4 §3)
+#
+# Scenarios mirror smoke_update.sh:
+#   1. v0.3.0 AGENTS.md (doc: AGENTS, no markers) -> wrapped.
+#   2. LFG-installed root templates/ -> moved to .log-file-genius/.backups/.
+#   3. user-authored AGENTS.md -> block prepended, content preserved.
+#   4. user-authored root templates/ -> left in place.
+#   5. Notepad CRLF+BOM v0.3.0 AGENTS.md -> wrapped + normalized (no BOM, LF).
+#   6. repeated merge is a byte-identical no-op.
+
+$ErrorActionPreference = "Stop"
+
+$REPO        = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$LFG_PY      = Join-Path $REPO "product\scripts\lfg.py"
+$MATCH       = Join-Path $REPO "product\scripts\update_template_hashes.py"
+
+$py = $null
+if (Get-Command python -ErrorAction SilentlyContinue) { $py = "python" }
+elseif (Get-Command python3 -ErrorAction SilentlyContinue) { $py = "python3" }
+if (-not $py) { Write-Host "FAIL: python not found (required for merge)"; exit 1 }
+
+function Fail($msg) { Write-Host "FAIL: $msg"; exit 1 }
+
+function New-Tmp {
+    $p = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $p | Out-Null
+    return $p
+}
+
+function Get-V030Agents($dest) {
+    # `git show` writes to stdout; capture as bytes-safe text and write LF.
+    $content = & git -C $REPO show "v0.3.0:product/AGENTS.md"
+    # $content is an array of lines (CRLF stripped by PowerShell); rejoin with LF.
+    $text = ($content -join "`n") + "`n"
+    [System.IO.File]::WriteAllText($dest, $text, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+# Mirror update.ps1's backup-move logic. Returns the backup dir path if it moved,
+# or $null if root templates/ was left in place / absent.
+function Move-LfgTemplates($projectRoot) {
+    $rootTemplates = Join-Path $projectRoot "templates"
+    if (-not (Test-Path $rootTemplates -PathType Container)) { return $null }
+    & $py $MATCH --match-dir $rootTemplates *> $null
+    if ($LASTEXITCODE -eq 0) {
+        $stamp = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+        $rand  = Get-Random
+        $backup = Join-Path $projectRoot ".log-file-genius\.backups\templates-$stamp-$rand"
+        New-Item -ItemType Directory -Path (Split-Path $backup -Parent) -Force | Out-Null
+        Move-Item -Path $rootTemplates -Destination $backup
+        return $backup
+    }
+    return $null
+}
+
+$tmps = @()
+try {
+    # --- Scenario 1: v0.3.0 AGENTS.md (no markers) -> wrapped --------------
+    $t1 = New-Tmp; $tmps += $t1
+    $a1 = Join-Path $t1 "AGENTS.md"
+    Get-V030Agents $a1
+    $txt = [System.IO.File]::ReadAllText($a1)
+    if ($txt -match 'LFG:BEGIN') { Fail "scenario 1: v0.3.0 fixture already has markers" }
+    & $py $LFG_PY merge-agents-md --to $a1 *> $null
+    $txt = [System.IO.File]::ReadAllText($a1)
+    if ($txt -notmatch '<!-- LFG:BEGIN v') { Fail "scenario 1: BEGIN marker not added" }
+    if ($txt -notmatch '<!-- LFG:END -->') { Fail "scenario 1: END marker not added" }
+    if ($txt -notmatch '(?m)^doc: AGENTS$') { Fail "scenario 1: canonical body missing" }
+    if (([regex]::Matches($txt, 'LFG:BEGIN')).Count -ne 1) { Fail "scenario 1: more than one BEGIN marker" }
+    Write-Host "  ok scenario 1: v0.3.0 AGENTS.md wrapped"
+
+    # --- Scenario 2: LFG-installed root templates/ -> moved ----------------
+    $t2 = New-Tmp; $tmps += $t2
+    New-Item -ItemType Directory -Path (Join-Path $t2 ".log-file-genius") | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $t2 "templates") | Out-Null
+    Copy-Item (Join-Path $REPO "product\templates\CHANGELOG_template.md") (Join-Path $t2 "templates\CHANGELOG_template.md")
+    $backup = Move-LfgTemplates $t2
+    if (Test-Path (Join-Path $t2 "templates") -PathType Container) { Fail "scenario 2: root templates/ still present" }
+    if (-not $backup) { Fail "scenario 2: no backup dir reported" }
+    if (-not (Test-Path $backup -PathType Container)) { Fail "scenario 2: backup dir does not exist" }
+    if (-not (Test-Path (Join-Path $backup "CHANGELOG_template.md"))) { Fail "scenario 2: backed-up template missing" }
+    if ($backup -notlike "*\.log-file-genius\.backups\templates-*") { Fail "scenario 2: backup not under .log-file-genius/.backups/" }
+    Write-Host "  ok scenario 2: LFG-installed root templates/ moved to backups"
+
+    # --- Scenario 3: user-authored AGENTS.md -> block prepended ------------
+    $t3 = New-Tmp; $tmps += $t3
+    $a3 = Join-Path $t3 "AGENTS.md"
+    $sentinel = "USER_SENTINEL_4f3a9b_KEEP_ME"
+    [System.IO.File]::WriteAllText($a3, "# My Project Agent Notes`n`n$sentinel - custom team instructions.`n", (New-Object System.Text.UTF8Encoding($false)))
+    & $py $LFG_PY merge-agents-md --to $a3 *> $null
+    $txt = [System.IO.File]::ReadAllText($a3)
+    if ($txt -notmatch [regex]::Escape($sentinel)) { Fail "scenario 3: user sentinel lost (data loss!)" }
+    if ($txt -notmatch '<!-- LFG:BEGIN v') { Fail "scenario 3: BEGIN marker not prepended" }
+    if ($txt -notmatch '<!-- LFG:END -->') { Fail "scenario 3: END marker missing" }
+    $beginIdx = $txt.IndexOf("LFG:BEGIN")
+    $sentIdx  = $txt.IndexOf($sentinel)
+    if ($beginIdx -ge $sentIdx) { Fail "scenario 3: block not prepended above user content" }
+    Write-Host "  ok scenario 3: user-authored AGENTS.md preserved, block prepended above"
+
+    # --- Scenario 4: user-authored root templates/ -> left in place --------
+    $t4 = New-Tmp; $tmps += $t4
+    New-Item -ItemType Directory -Path (Join-Path $t4 ".log-file-genius") | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $t4 "templates") | Out-Null
+    [System.IO.File]::WriteAllText((Join-Path $t4 "templates\my_template.md"), "my own template content - not shipped by LFG $(Get-Random)`n", (New-Object System.Text.UTF8Encoding($false)))
+    $backup4 = Move-LfgTemplates $t4
+    if (-not (Test-Path (Join-Path $t4 "templates") -PathType Container)) { Fail "scenario 4: user templates/ was moved" }
+    if (-not (Test-Path (Join-Path $t4 "templates\my_template.md"))) { Fail "scenario 4: user template file disappeared" }
+    if ($backup4) { Fail "scenario 4: a backup was created for user-authored templates" }
+    if (Test-Path (Join-Path $t4 ".log-file-genius\.backups") -PathType Container) { Fail "scenario 4: backups dir created for user templates" }
+    Write-Host "  ok scenario 4: user-authored root templates/ left in place"
+
+    # --- Scenario 5: Notepad CRLF+BOM v0.3.0 AGENTS.md -> wrapped+normalized -
+    $t5 = New-Tmp; $tmps += $t5
+    $lf5 = Join-Path $t5 "lf.md"
+    $a5  = Join-Path $t5 "AGENTS.md"
+    Get-V030Agents $lf5
+    # Re-encode as UTF-8 BOM + CRLF (simulating a Notepad save on Windows).
+    $body = [System.IO.File]::ReadAllText($lf5)
+    $crlf = $body -replace "`n", "`r`n"
+    $bom  = [byte[]](0xEF,0xBB,0xBF)
+    $bytes = $bom + [System.Text.Encoding]::UTF8.GetBytes($crlf)
+    [System.IO.File]::WriteAllBytes($a5, $bytes)
+    # Sanity: fixture has a BOM and CR bytes.
+    $raw = [System.IO.File]::ReadAllBytes($a5)
+    if (-not ($raw[0] -eq 0xEF -and $raw[1] -eq 0xBB -and $raw[2] -eq 0xBF)) { Fail "scenario 5: fixture missing BOM" }
+    if (-not ($raw -contains 0x0D)) { Fail "scenario 5: fixture missing CRLF" }
+    & $py $LFG_PY merge-agents-md --to $a5 *> $null
+    $raw = [System.IO.File]::ReadAllBytes($a5)
+    $txt = [System.Text.Encoding]::UTF8.GetString($raw)
+    if ($txt -notmatch '<!-- LFG:BEGIN v') { Fail "scenario 5: markers not detected/added" }
+    if ($raw.Length -ge 3 -and $raw[0] -eq 0xEF -and $raw[1] -eq 0xBB -and $raw[2] -eq 0xBF) { Fail "scenario 5: BOM not stripped on write" }
+    if ($raw -contains 0x0D) { Fail "scenario 5: CRLF not normalized to LF" }
+    Write-Host "  ok scenario 5: Notepad CRLF+BOM v0.3.0 file wrapped and normalized"
+
+    # --- Scenario 6: repeated merge is a byte-identical no-op --------------
+    $before = [System.IO.File]::ReadAllBytes($a1)
+    $out6 = & $py $LFG_PY merge-agents-md --to $a1 2>&1 | Out-String
+    if ($out6 -notmatch 'up to date') { Fail "scenario 6: re-merge did not report up-to-date: $out6" }
+    $after = [System.IO.File]::ReadAllBytes($a1)
+    if (-not ([System.Linq.Enumerable]::SequenceEqual($before, $after))) { Fail "scenario 6: re-merge changed the file (not idempotent)" }
+    Write-Host "  ok scenario 6: repeated merge is a byte-identical no-op"
+
+    Write-Host "PASS (powershell)"
+}
+finally {
+    foreach ($t in $tmps) {
+        if ($t -and (Test-Path $t)) { Remove-Item -Recurse -Force $t -ErrorAction SilentlyContinue }
+    }
+}

--- a/product/tests/smoke_update.sh
+++ b/product/tests/smoke_update.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# product/tests/smoke_update.sh
+# Cross-platform UPDATE smoke test (bash) — Spec 4 brownfield-safe update.
+#
+# The full update.sh requires a real .log-file-genius/ git submodule and does a
+# `git fetch` against origin — too heavy and network-dependent for a smoke test.
+# So we exercise the SPECIFIC new behaviors update.sh performs, using the exact
+# same entrypoints update.sh calls:
+#   - AGENTS.md merge:      lfg.py merge-agents-md --to <path>   (Spec 4 §1)
+#   - root templates/ move: update_template_hashes.py --match-dir + the
+#                           backup-move shell logic from update.sh             (Spec 4 §3)
+#
+# Scenarios (mirror the "test_update_smoke" Test-plan row in SPEC-04):
+#   1. v0.3.0 AGENTS.md (doc: AGENTS frontmatter, NO markers) -> update WRAPS it
+#      (markers added, canonical body regenerated).
+#   2. LFG-installed root templates/ (real product template, hash in manifest)
+#      -> moved to .log-file-genius/.backups/templates-*/ (root gone, backup exists).
+#   3. USER-authored AGENTS.md (no doc: AGENTS, custom sentinel) -> block PREPENDED
+#      above; user content + sentinel preserved.
+#   4. USER-authored root templates/ (file whose hash is NOT in the manifest)
+#      -> LEFT in place (not moved).
+#   5. Notepad-style v0.3.0 AGENTS.md (CRLF + UTF-8 BOM, no markers) -> update
+#      wraps it; output normalized to LF + no-BOM, markers detected.
+#   6. Repeated merge on an up-to-date managed file is a byte-identical no-op.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+LFG_PY="$REPO/product/scripts/lfg.py"
+MATCH_HELPER="$REPO/product/scripts/update_template_hashes.py"
+
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then PYTHON_BIN="python3";
+elif command -v python >/dev/null 2>&1; then PYTHON_BIN="python"; fi
+if [ -z "$PYTHON_BIN" ]; then echo "FAIL: python not found (required for merge)"; exit 1; fi
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# Mirror update.sh's backup-move block (Spec 4 §3). Given a project root, decide
+# whether root templates/ is LFG-installed (>=1 hash matches the manifest) and
+# move it to .log-file-genius/.backups/templates-<unixtime>/ if so.
+move_lfg_templates() {
+    local project_root="$1"
+    local root_templates="$project_root/templates"
+    [ -d "$root_templates" ] || return 0
+    if "$PYTHON_BIN" "$MATCH_HELPER" --match-dir "$root_templates" >/dev/null 2>&1; then
+        local backup_dir="$project_root/.log-file-genius/.backups/templates-$(date +%s)-$RANDOM"
+        mkdir -p "$(dirname "$backup_dir")"
+        mv "$root_templates" "$backup_dir"
+        echo "$backup_dir"
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: v0.3.0 AGENTS.md (no markers, doc: AGENTS) -> wrapped on update.
+# ---------------------------------------------------------------------------
+TMP1="$(mktemp -d)"; trap 'rm -rf "$TMP1"' EXIT
+git -C "$REPO" show v0.3.0:product/AGENTS.md > "$TMP1/AGENTS.md"
+grep -q 'LFG:BEGIN' "$TMP1/AGENTS.md" && fail "v0.3.0 fixture unexpectedly already has markers"
+"$PYTHON_BIN" "$LFG_PY" merge-agents-md --to "$TMP1/AGENTS.md" >/dev/null
+grep -q '<!-- LFG:BEGIN v' "$TMP1/AGENTS.md" || fail "scenario 1: BEGIN marker not added after wrap"
+grep -q '<!-- LFG:END -->' "$TMP1/AGENTS.md" || fail "scenario 1: END marker not added after wrap"
+grep -q '^doc: AGENTS$' "$TMP1/AGENTS.md" || fail "scenario 1: canonical body (doc: AGENTS) not present after wrap"
+[ "$(grep -c 'LFG:BEGIN' "$TMP1/AGENTS.md")" = "1" ] || fail "scenario 1: more than one BEGIN marker"
+echo "  ok scenario 1: v0.3.0 AGENTS.md wrapped"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: LFG-installed root templates/ -> moved to backups.
+# ---------------------------------------------------------------------------
+TMP2="$(mktemp -d)"; trap 'rm -rf "$TMP1" "$TMP2"' EXIT
+mkdir -p "$TMP2/.log-file-genius" "$TMP2/templates"
+# Copy a real shipped template so its SHA-256 is in the manifest.
+cp "$REPO/product/templates/CHANGELOG_template.md" "$TMP2/templates/CHANGELOG_template.md"
+BACKUP="$(move_lfg_templates "$TMP2")"
+[ -d "$TMP2/templates" ] && fail "scenario 2: root templates/ still present (should have been moved)"
+[ -n "$BACKUP" ] || fail "scenario 2: no backup dir reported"
+[ -d "$BACKUP" ] || fail "scenario 2: backup dir does not exist: $BACKUP"
+[ -f "$BACKUP/CHANGELOG_template.md" ] || fail "scenario 2: backed-up template missing"
+case "$BACKUP" in
+    "$TMP2/.log-file-genius/.backups/templates-"*) : ;;
+    *) fail "scenario 2: backup not under .log-file-genius/.backups/: $BACKUP" ;;
+esac
+echo "  ok scenario 2: LFG-installed root templates/ moved to backups"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: USER-authored AGENTS.md (no doc: AGENTS) -> block PREPENDED above.
+# ---------------------------------------------------------------------------
+TMP3="$(mktemp -d)"; trap 'rm -rf "$TMP1" "$TMP2" "$TMP3"' EXIT
+SENTINEL="USER_SENTINEL_4f3a9b_KEEP_ME"
+printf '# My Project Agent Notes\n\n%s — custom team instructions.\n' "$SENTINEL" > "$TMP3/AGENTS.md"
+"$PYTHON_BIN" "$LFG_PY" merge-agents-md --to "$TMP3/AGENTS.md" >/dev/null
+grep -q "$SENTINEL" "$TMP3/AGENTS.md" || fail "scenario 3: user sentinel lost (data loss!)"
+grep -q '<!-- LFG:BEGIN v' "$TMP3/AGENTS.md" || fail "scenario 3: BEGIN marker not prepended"
+grep -q '<!-- LFG:END -->' "$TMP3/AGENTS.md" || fail "scenario 3: END marker missing"
+# Block must come ABOVE the user content.
+BEGIN_LINE="$(grep -n 'LFG:BEGIN' "$TMP3/AGENTS.md" | head -1 | cut -d: -f1)"
+SENT_LINE="$(grep -n "$SENTINEL" "$TMP3/AGENTS.md" | head -1 | cut -d: -f1)"
+[ "$BEGIN_LINE" -lt "$SENT_LINE" ] || fail "scenario 3: block not prepended above user content"
+echo "  ok scenario 3: user-authored AGENTS.md preserved, block prepended above"
+
+# ---------------------------------------------------------------------------
+# Scenario 4: USER-authored root templates/ (hash NOT in manifest) -> LEFT alone.
+# ---------------------------------------------------------------------------
+TMP4="$(mktemp -d)"; trap 'rm -rf "$TMP1" "$TMP2" "$TMP3" "$TMP4"' EXIT
+mkdir -p "$TMP4/.log-file-genius" "$TMP4/templates"
+printf 'my own template content — not shipped by LFG %s\n' "$RANDOM" > "$TMP4/templates/my_template.md"
+BACKUP4="$(move_lfg_templates "$TMP4")"
+[ -d "$TMP4/templates" ] || fail "scenario 4: user templates/ was moved (should be left in place!)"
+[ -f "$TMP4/templates/my_template.md" ] || fail "scenario 4: user template file disappeared"
+[ -z "$BACKUP4" ] || fail "scenario 4: a backup was created for user-authored templates"
+[ -d "$TMP4/.log-file-genius/.backups" ] && fail "scenario 4: a backups dir was created for user templates"
+echo "  ok scenario 4: user-authored root templates/ left in place"
+
+# ---------------------------------------------------------------------------
+# Scenario 5: Notepad-style v0.3.0 AGENTS.md (CRLF + UTF-8 BOM, no markers).
+# Update must wrap it AND normalize output to LF + no-BOM, markers detected.
+# (This is the realistic brownfield path: v0.3.0 had no markers.)
+# ---------------------------------------------------------------------------
+TMP5="$(mktemp -d)"; trap 'rm -rf "$TMP1" "$TMP2" "$TMP3" "$TMP4" "$TMP5"' EXIT
+git -C "$REPO" show v0.3.0:product/AGENTS.md > "$TMP5/lf.md"
+# Re-encode as UTF-8 BOM + CRLF (simulating a Notepad save on Windows).
+"$PYTHON_BIN" - "$TMP5/lf.md" "$TMP5/AGENTS.md" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+text = open(src, "rb").read().decode("utf-8")
+crlf = text.replace("\n", "\r\n")
+open(dst, "wb").write(b"\xef\xbb\xbf" + crlf.encode("utf-8"))
+PY
+# Count CR (0x0D) bytes reliably via python — git-bash grep treats CR as a line
+# terminator and won't match it on a CRLF file, so byte-counting is the only
+# trustworthy check here.
+cr_count() { "$PYTHON_BIN" -c "import sys; sys.stdout.write(str(open(sys.argv[1],'rb').read().count(b'\r')))" "$1"; }
+has_bom()  { head -c 3 "$1" | grep -q $'\xEF\xBB\xBF'; }
+# Sanity: the fixture really has a BOM and CR bytes before the merge.
+has_bom "$TMP5/AGENTS.md" || fail "scenario 5: fixture missing BOM"
+[ "$(cr_count "$TMP5/AGENTS.md")" -gt 0 ] || fail "scenario 5: fixture missing CRLF"
+"$PYTHON_BIN" "$LFG_PY" merge-agents-md --to "$TMP5/AGENTS.md" >/dev/null
+grep -q '<!-- LFG:BEGIN v' "$TMP5/AGENTS.md" || fail "scenario 5: markers not detected/added"
+# Output normalized: no BOM, no CR.
+has_bom "$TMP5/AGENTS.md" && fail "scenario 5: BOM not stripped on write" || true
+[ "$(cr_count "$TMP5/AGENTS.md")" = "0" ] || fail "scenario 5: CRLF not normalized to LF"
+echo "  ok scenario 5: Notepad CRLF+BOM v0.3.0 file wrapped and normalized"
+
+# ---------------------------------------------------------------------------
+# Scenario 6: repeated merge on an up-to-date managed file is a no-op.
+# ---------------------------------------------------------------------------
+BEFORE6="$(cksum < "$TMP1/AGENTS.md")"
+OUT6="$("$PYTHON_BIN" "$LFG_PY" merge-agents-md --to "$TMP1/AGENTS.md" 2>&1)"
+echo "$OUT6" | grep -qi 'up to date' || fail "scenario 6: re-merge did not report up-to-date: $OUT6"
+AFTER6="$(cksum < "$TMP1/AGENTS.md")"
+[ "$BEFORE6" = "$AFTER6" ] || fail "scenario 6: re-merge changed the file (not idempotent)"
+echo "  ok scenario 6: repeated merge is a byte-identical no-op"
+
+echo "PASS (bash)"

--- a/product/tests/test_agents_merge.py
+++ b/product/tests/test_agents_merge.py
@@ -1,0 +1,415 @@
+"""Tests for the managed-block AGENTS.md merge engine (Spec 4 §1 / T4).
+
+Covers every spec row: fresh install, markers-present interior replacement,
+forward-version refusal, the pre-marker LFG fingerprint bridge (loaded from
+`git show v0.3.0:product/AGENTS.md`), user-authored prepend, the --no-wrap
+escape hatch, CRLF+BOM normalization, idempotency, and atomicity.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from agents_merge import (  # noqa: E402
+    LFG_BEGIN_RE,
+    LFG_END_LIT,
+    CorruptMarkerError,
+    ForwardVersionError,
+    atomic_write,
+    looks_like_lfg,
+    merge_into_existing,
+    read_text_normalized,
+)
+
+RUNNING = "0.4.0"
+
+# A representative rendered block (BEGIN + body + END), as render_block emits.
+BLOCK = (
+    "<!-- LFG:BEGIN v0.4.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+    "---\n"
+    "doc: AGENTS\n"
+    "---\n"
+    "\n"
+    "# Log File Genius — AGENTS guidance\n"
+    "\n"
+    "Generated content here.\n"
+    "<!-- LFG:END -->\n"
+)
+
+
+# --- Fixtures ----------------------------------------------------------------
+
+def _v030_agents_md() -> str:
+    """The only historical LFG AGENTS.md (v0.3.0), loaded via git show."""
+    repo_root = Path(__file__).resolve().parents[2]
+    out = subprocess.run(
+        ["git", "show", "v0.3.0:product/AGENTS.md"],
+        cwd=repo_root,
+        capture_output=True,
+        check=True,
+    )
+    # Decode explicitly as UTF-8 (the file contains an em-dash); the Windows
+    # console default (cp1252) would choke on it.
+    return out.stdout.decode("utf-8").replace("\r\n", "\n").replace("\r", "\n")
+
+
+CODEX_AGENTS_MD = """\
+# AGENTS.md
+
+This file gives instructions to coding agents working in this repo.
+
+## Build
+Run `make build` to compile.
+
+## Conventions
+- Use tabs, not spaces.
+- Keep functions short.
+"""
+
+
+# --- looks_like_lfg ----------------------------------------------------------
+
+def test_looks_like_lfg_primary_frontmatter_signal():
+    content = "---\ndoc: AGENTS\nrelated:\n  state: ./logs/STATE.md\n---\n\n# Hi\n"
+    assert looks_like_lfg(content) is True
+
+
+def test_looks_like_lfg_tolerates_leading_blank_lines():
+    content = "\n\n---\ndoc: AGENTS\n---\n"
+    assert looks_like_lfg(content) is True
+
+
+def test_looks_like_lfg_v030_fixture_is_lfg():
+    content = _v030_agents_md()
+    assert looks_like_lfg(content) is True
+
+
+def test_looks_like_lfg_codex_file_is_not_lfg():
+    assert looks_like_lfg(CODEX_AGENTS_MD) is False
+
+
+def test_looks_like_lfg_empty_is_false():
+    assert looks_like_lfg("") is False
+
+
+def test_looks_like_lfg_defensive_fallback_two_signals():
+    # No frontmatter, but two distinctive signals: command list + 5-doc paths.
+    content = (
+        "# Some doc\n"
+        "Use lfg validate, lfg prime, lfg generate.\n"
+        "See logs/STATE.md, logs/CHANGELOG.md, logs/DEVLOG.md.\n"
+    )
+    assert looks_like_lfg(content) is True
+
+
+def test_looks_like_lfg_defensive_fallback_one_signal_is_false():
+    # Only the command list signal; one signal is not enough.
+    content = "Use lfg validate, lfg prime, lfg generate.\n"
+    assert looks_like_lfg(content) is False
+
+
+def test_looks_like_lfg_doc_other_value_not_lfg():
+    content = "---\ndoc: README\n---\n\n# Not us\n"
+    assert looks_like_lfg(content) is False
+
+
+# --- merge_into_existing: case 1 (fresh) -------------------------------------
+
+def test_merge_fresh_none_returns_block():
+    assert merge_into_existing(None, BLOCK, RUNNING) == BLOCK
+
+
+def test_merge_fresh_blank_returns_block():
+    assert merge_into_existing("   \n\n  ", BLOCK, RUNNING) == BLOCK
+
+
+# --- merge_into_existing: case 2 (markers present) ---------------------------
+
+def test_merge_markers_present_replaces_interior_preserves_surroundings():
+    existing = (
+        "# My personal notes above the block\n"
+        "Keep this line.\n"
+        "\n"
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "old generated body\n"
+        "<!-- LFG:END -->\n"
+        "\n"
+        "## My notes below the block\n"
+        "Keep this too.\n"
+    )
+    result = merge_into_existing(existing, BLOCK, RUNNING)
+    assert "# My personal notes above the block" in result
+    assert "Keep this line." in result
+    assert "## My notes below the block" in result
+    assert "Keep this too." in result
+    # Old body gone, new block present.
+    assert "old generated body" not in result
+    assert "Generated content here." in result
+    # The new block sits exactly where the old one was. block ends in a "\n";
+    # the merge absorbs one newline that followed END, so the blank line that
+    # separated the old block from the notes below is reproduced exactly once.
+    expected = (
+        "# My personal notes above the block\n"
+        "Keep this line.\n"
+        "\n"
+        + BLOCK
+        + "\n"
+        "## My notes below the block\n"
+        "Keep this too.\n"
+    )
+    assert result == expected
+
+
+def test_merge_forward_version_raises():
+    existing = (
+        "<!-- LFG:BEGIN v99.0.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "future body\n"
+        "<!-- LFG:END -->\n"
+    )
+    with pytest.raises(ForwardVersionError):
+        merge_into_existing(existing, BLOCK, RUNNING)
+
+
+def test_merge_forward_version_force_downgrade_replaces_no_raise():
+    existing = (
+        "<!-- LFG:BEGIN v99.0.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "future body\n"
+        "<!-- LFG:END -->\n"
+    )
+    # With force_downgrade, the newer-marker check is skipped and the interior
+    # is replaced anyway (the lone trailing newline after END is absorbed).
+    result = merge_into_existing(existing, BLOCK, RUNNING, force_downgrade=True)
+    assert result == BLOCK
+    assert "future body" not in result
+
+
+def test_merge_equal_version_replaces_no_raise():
+    existing = (
+        "<!-- LFG:BEGIN v0.4.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "same-version body\n"
+        "<!-- LFG:END -->\n"
+    )
+    result = merge_into_existing(existing, BLOCK, RUNNING)
+    # The lone trailing newline after END is absorbed into the managed region.
+    assert result == BLOCK
+
+
+# --- Adversarial markers (SHOULD-FIX 3 / BLOCKER 1) --------------------------
+
+def test_merge_begin_without_end_raises_corrupt():
+    # BEGIN marker present, no END anywhere -> cannot slice safely -> error.
+    existing = (
+        "# My notes\n"
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "orphaned body with no end marker\n"
+        "more user content\n"
+    )
+    with pytest.raises(CorruptMarkerError):
+        merge_into_existing(existing, BLOCK, RUNNING)
+
+
+def test_merge_begin_without_end_raises_even_with_no_wrap():
+    # A corrupt half-marker errors regardless of --no-wrap (allow_wrap=False):
+    # the user must repair the file; we never silently prepend a 2nd BEGIN.
+    existing = (
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "orphaned body\n"
+    )
+    with pytest.raises(CorruptMarkerError):
+        merge_into_existing(existing, BLOCK, RUNNING, allow_wrap=False)
+
+
+def test_merge_end_before_begin_raises_corrupt():
+    # END literal appears BEFORE the BEGIN match -> still corrupt (we can't
+    # form a valid [BEGIN..END] region). Now covered by Blocker 1's guard.
+    existing = (
+        "<!-- LFG:END -->\n"
+        "stray content\n"
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "body after a premature end\n"
+    )
+    with pytest.raises(CorruptMarkerError):
+        merge_into_existing(existing, BLOCK, RUNNING)
+
+
+def test_merge_two_full_blocks_rewrites_first_preserves_second():
+    # Two complete BEGIN+END pairs. Behavior (documented & deterministic):
+    # search() finds the FIRST begin, find() finds the FIRST end, so case 2
+    # slices [first-BEGIN .. first-END] and replaces it with `block`. The
+    # SECOND full block is part of `after` and is preserved verbatim. No
+    # content is lost; re-running is idempotent on the first block. We pick
+    # this over erroring because a doubled FULL block (unlike a corrupt
+    # half-marker) is unambiguous to slice.
+    second_block = (
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "second old body\n"
+        "<!-- LFG:END -->\n"
+    )
+    existing = (
+        "# Top notes\n"
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "first old body\n"
+        "<!-- LFG:END -->\n"
+        "# Middle notes\n"
+        + second_block
+        + "# Bottom notes\n"
+    )
+    result = merge_into_existing(existing, BLOCK, RUNNING)
+    # First block rewritten with the new content.
+    assert "first old body" not in result
+    assert "Generated content here." in result
+    # Second block + all user notes preserved verbatim.
+    assert "second old body" in result
+    assert "# Top notes" in result
+    assert "# Middle notes" in result
+    assert "# Bottom notes" in result
+    # Deterministic: exactly one BEGIN was rewritten, the second remains.
+    assert result.count("<!-- LFG:BEGIN v") == 2
+
+
+# --- merge_into_existing: case 3 (no markers + LFG fingerprint) --------------
+
+def test_merge_v030_no_markers_returns_block():
+    existing = _v030_agents_md()
+    assert LFG_BEGIN_RE.search(existing) is None  # confirm fixture has no markers
+    result = merge_into_existing(existing, BLOCK, RUNNING)
+    assert result == BLOCK
+
+
+# --- merge_into_existing: case 4 (user-authored) -----------------------------
+
+def test_merge_codex_prepends_block_preserves_user_content():
+    result = merge_into_existing(CODEX_AGENTS_MD, BLOCK, RUNNING)
+    assert result == BLOCK + "\n" + CODEX_AGENTS_MD
+    # User content still fully present.
+    assert "Run `make build` to compile." in result
+    assert "Use tabs, not spaces." in result
+    # Block is at the top.
+    assert result.startswith(BLOCK)
+
+
+def test_merge_no_wrap_on_lfg_file_prepends_instead_of_wrapping():
+    existing = _v030_agents_md()
+    result = merge_into_existing(existing, BLOCK, RUNNING, allow_wrap=False)
+    # With wrapping disabled, LFG-looking content is treated as user content:
+    # block prepended, old content preserved below.
+    assert result == BLOCK + "\n" + existing
+    assert existing in result
+
+
+# --- Idempotency -------------------------------------------------------------
+
+def test_merge_idempotent_markers_present():
+    existing = (
+        "# Note above\n"
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "old body\n"
+        "<!-- LFG:END -->\n"
+        "# Note below\n"
+    )
+    once = merge_into_existing(existing, BLOCK, RUNNING)
+    twice = merge_into_existing(once, BLOCK, RUNNING)
+    assert once == twice
+
+
+# --- Encoding / IO -----------------------------------------------------------
+
+def test_read_text_normalized_strips_bom_and_normalizes_crlf(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    raw = (
+        "﻿"  # UTF-8 BOM
+        "# Note above\r\n"
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\r\n"
+        "old body\r\n"
+        "<!-- LFG:END -->\r\n"
+    )
+    path.write_bytes(raw.encode("utf-8"))
+
+    content = read_text_normalized(path)
+    assert "\r" not in content
+    assert not content.startswith("﻿")
+    # Markers still detected on normalized content.
+    assert LFG_BEGIN_RE.search(content) is not None
+    assert LFG_END_LIT in content
+
+
+def test_read_text_normalized_missing_file_returns_empty(tmp_path):
+    assert read_text_normalized(tmp_path / "nope.md") == ""
+
+
+def test_atomic_write_round_trip_is_clean_lf_no_bom(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    atomic_write(path, BLOCK)
+    raw = path.read_bytes()
+    assert b"\r" not in raw
+    assert not raw.startswith(b"\xef\xbb\xbf")  # no UTF-8 BOM
+    assert raw.decode("utf-8") == BLOCK
+    # No leftover tmp file.
+    assert not (tmp_path / "AGENTS.md.lfg-tmp").exists()
+
+
+def test_crlf_bom_input_full_round_trip(tmp_path):
+    """Notepad-edited file: read normalizes, merge runs, write is clean."""
+    path = tmp_path / "AGENTS.md"
+    raw = (
+        "﻿"
+        "# User note\r\n"
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\r\n"
+        "old body\r\n"
+        "<!-- LFG:END -->\r\n"
+    )
+    path.write_bytes(raw.encode("utf-8"))
+
+    existing = read_text_normalized(path)
+    merged = merge_into_existing(existing, BLOCK, RUNNING)
+    atomic_write(path, merged)
+
+    out = path.read_bytes()
+    assert b"\r" not in out
+    assert not out.startswith(b"\xef\xbb\xbf")
+    text = out.decode("utf-8")
+    assert "# User note" in text
+    assert "Generated content here." in text
+    assert "old body" not in text
+
+
+# --- Atomicity ---------------------------------------------------------------
+
+def test_atomic_write_failure_before_replace_leaves_original(tmp_path, monkeypatch):
+    path = tmp_path / "AGENTS.md"
+    original = "ORIGINAL CONTENT\n"
+    path.write_text(original, encoding="utf-8", newline="\n")
+    original_bytes = path.read_bytes()
+
+    def boom(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+    with pytest.raises(OSError):
+        atomic_write(path, "NEW CONTENT THAT MUST NOT LAND\n")
+
+    # Original file is byte-for-byte unchanged.
+    assert path.read_bytes() == original_bytes
+    # NIT 7: no stray tmp file left behind after a failed replace.
+    assert not (tmp_path / "AGENTS.md.lfg-tmp").exists()
+
+
+def test_atomic_write_failure_during_write_cleans_tmp(tmp_path, monkeypatch):
+    # If fsync raises mid-write, the tmp file must be unlinked (NIT 7) and the
+    # original target (absent here) must not be created.
+    path = tmp_path / "AGENTS.md"
+
+    def boom_fsync(fd):
+        raise OSError("simulated fsync failure")
+
+    monkeypatch.setattr(os, "fsync", boom_fsync)
+
+    with pytest.raises(OSError):
+        atomic_write(path, "CONTENT\n")
+
+    assert not (tmp_path / "AGENTS.md.lfg-tmp").exists()
+    assert not path.exists()

--- a/product/tests/test_check_version.py
+++ b/product/tests/test_check_version.py
@@ -1,0 +1,208 @@
+"""Tests for the version comparator in check-version.py.
+
+Pins the direction of the validators' "update available" message so the
+backwards-comparison bug (Spec 4 §4 / issue #2) can't regress.
+
+check-version.py is not importable by name (hyphen), so load it via
+importlib from its file path.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SPEC = importlib.util.spec_from_file_location(
+    "check_version", _SCRIPTS / "check-version.py"
+)
+check_version = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_version"] = check_version
+_SPEC.loader.exec_module(check_version)
+
+compare_versions = check_version.compare_versions
+parse_version = check_version.parse_version
+
+
+# --- Direction pinning ------------------------------------------------------
+# Convention used by the validators: compare_versions(installed, latest).
+#   > 0  → installed is AHEAD of latest (NOT "update available")
+#   < 0  → installed is BEHIND latest  ("update available")
+#   == 0 → current / up to date
+
+
+def message_for(installed: str, latest: str) -> str:
+    """Mirror the validator's branching to assert on user-facing wording."""
+    result = compare_versions(installed, latest)
+    if result < 0:
+        return f"update available: v{latest} (you have v{installed})"
+    if result > 0:
+        return f"you are on v{installed}, newer than the latest-known v{latest}"
+    return "current"
+
+
+def test_ahead_is_not_update_available():
+    # The original bug: installed 0.3.0, latest-known 0.2.0.
+    assert compare_versions("0.3.0", "0.2.0") > 0
+    msg = message_for("0.3.0", "0.2.0")
+    assert "update available" not in msg
+    assert "newer" in msg
+
+
+def test_behind_is_update_available():
+    assert compare_versions("0.2.0", "0.3.0") < 0
+    msg = message_for("0.2.0", "0.3.0")
+    assert msg == "update available: v0.3.0 (you have v0.2.0)"
+
+
+def test_equal_is_current():
+    assert compare_versions("0.3.0", "0.3.0") == 0
+    assert message_for("0.3.0", "0.3.0") == "current"
+
+
+def test_minor_and_patch_precedence():
+    assert compare_versions("0.4.0", "0.3.9") > 0
+    assert compare_versions("1.0.0", "0.99.99") > 0
+    assert compare_versions("1.2.3", "1.2.4") < 0
+    assert compare_versions("1.3.0", "1.2.9") > 0
+
+
+# --- Pre-release suffix -----------------------------------------------------
+# Per semver: a pre-release sorts BEFORE its associated release.
+
+
+def test_prerelease_sorts_before_release():
+    assert compare_versions("1.2.3-rc.1", "1.2.3") < 0
+    assert compare_versions("1.2.3", "1.2.3-rc.1") > 0
+
+
+def test_prerelease_ordering():
+    # alpha < beta < rc (lexical), and rc.1 < rc.2 (numeric identifier).
+    assert compare_versions("1.0.0-alpha", "1.0.0-beta") < 0
+    assert compare_versions("1.0.0-rc.1", "1.0.0-rc.2") < 0
+    assert compare_versions("1.0.0-rc.2", "1.0.0-rc.10") < 0  # numeric, not lexical
+    # numeric identifiers have lower precedence than alphanumeric
+    assert compare_versions("1.0.0-1", "1.0.0-alpha") < 0
+
+
+def test_prerelease_against_lower_release_still_loses_to_higher_core():
+    # 1.2.3-rc.1 is still less than 1.2.4 (core wins).
+    assert compare_versions("1.2.3-rc.1", "1.2.4") < 0
+    # but greater than 1.2.2.
+    assert compare_versions("1.2.3-rc.1", "1.2.2") > 0
+
+
+# --- Build metadata ---------------------------------------------------------
+# Per semver: build metadata is ignored for precedence.
+
+
+def test_build_metadata_ignored():
+    assert compare_versions("1.2.3+local", "1.2.3") == 0
+    assert compare_versions("1.2.3+local.abc123", "1.2.3+other.def") == 0
+    assert compare_versions("1.2.3", "1.2.3+build.99") == 0
+
+
+def test_build_metadata_does_not_change_direction():
+    assert compare_versions("0.4.0+local", "0.3.0") > 0
+    assert compare_versions("0.2.0+ci.5", "0.3.0") < 0
+
+
+def test_prerelease_with_build_metadata():
+    # build metadata stripped, pre-release still applies.
+    assert compare_versions("1.2.3-rc.1+local.abc123", "1.2.3") < 0
+    assert compare_versions("1.2.3-rc.1+a", "1.2.3-rc.1+b") == 0
+
+
+# --- Tolerant parsing --------------------------------------------------------
+
+
+def test_leading_v_tolerated():
+    assert compare_versions("v0.4.0", "0.4.0") == 0
+    assert compare_versions("v0.4.0", "v0.3.0") > 0
+
+
+def test_missing_components_default_to_zero():
+    assert compare_versions("1", "1.0.0") == 0
+    assert compare_versions("1.2", "1.2.0") == 0
+    assert compare_versions("1.2", "1.2.1") < 0
+
+
+def test_parse_version_shape():
+    core, pre = parse_version("1.2.3-rc.1+local")
+    assert core == (1, 2, 3)
+    assert pre == ("rc", 1)
+    core2, pre2 = parse_version("0.3.0")
+    assert core2 == (0, 3, 0)
+    assert pre2 == ()
+
+
+# --- Junk handling (SHOULD-FIX 5) -------------------------------------------
+# Truly non-numeric input must NOT parse to (0,0,0) and make garbage look
+# "behind" real versions (the spurious update-available bug). Valid-but-terse
+# inputs (leading v, missing minor/patch) are NOT junk and must still parse.
+
+import pytest  # noqa: E402
+
+UnparseableVersionError = check_version.UnparseableVersionError
+
+
+def test_parse_version_empty_is_junk():
+    with pytest.raises(UnparseableVersionError):
+        parse_version("")
+
+
+def test_parse_version_nonnumeric_is_junk():
+    with pytest.raises(UnparseableVersionError):
+        parse_version("abc")
+
+
+def test_parse_version_whitespace_is_junk():
+    with pytest.raises(UnparseableVersionError):
+        parse_version("   ")
+
+
+def test_parse_version_bare_v_is_junk():
+    # "v" strips to "" -> no numeric core.
+    with pytest.raises(UnparseableVersionError):
+        parse_version("v")
+
+
+def test_compare_versions_junk_returns_none():
+    # None == "cannot determine direction" -> validators stay silent.
+    assert compare_versions("", "0.3.0") is None
+    assert compare_versions("0.3.0", "abc") is None
+    assert compare_versions("garbage", "junk") is None
+
+
+def test_compare_versions_valid_terse_inputs_still_work():
+    # Regression guard: these are valid, not junk.
+    assert compare_versions("v0.4.0", "0.3.0") > 0
+    assert compare_versions("1", "1.0.0") == 0
+    assert compare_versions("1.2", "1.2.1") < 0
+
+
+# --- Checksum normalization (cross-platform stability) ----------------------
+# git re-encodes text files per platform: .ps1 ships with a UTF-8 BOM and
+# becomes CRLF on Windows checkout, while .py/.sh stay LF. compute_file_checksum
+# must hash CONTENT, not the checkout encoding, so a fixed VERSION.json baseline
+# passes on every platform. Regression guard for the shipped-broken-checksum bug.
+
+def test_checksum_ignores_bom_and_line_endings(tmp_path):
+    base = "line one\nline two\nline three\n"
+    lf = tmp_path / "lf.txt"
+    lf.write_bytes(base.encode("utf-8"))
+    crlf = tmp_path / "crlf.txt"
+    crlf.write_bytes(base.replace("\n", "\r\n").encode("utf-8"))
+    bom_crlf = tmp_path / "bom_crlf.txt"
+    bom_crlf.write_bytes(b"\xef\xbb\xbf" + base.replace("\n", "\r\n").encode("utf-8"))
+
+    h_lf = check_version.compute_file_checksum(lf)
+    assert check_version.compute_file_checksum(crlf) == h_lf
+    assert check_version.compute_file_checksum(bom_crlf) == h_lf
+
+
+def test_checksum_still_detects_content_change(tmp_path):
+    a = tmp_path / "a.txt"
+    a.write_bytes(b"real content\n")
+    b = tmp_path / "b.txt"
+    b.write_bytes(b"tampered content\n")
+    assert check_version.compute_file_checksum(a) != check_version.compute_file_checksum(b)

--- a/product/tests/test_generator_round_trip.py
+++ b/product/tests/test_generator_round_trip.py
@@ -1,0 +1,89 @@
+"""Spec 4 §1 round-trip tests for the canonical-body generator primitive.
+
+Proves the managed-block wrapper (render_block) round-trips cleanly back to
+the full output (render_full), that the BEGIN marker matches the spec's strict
+regex and carries the VERSION.json version, and that render_full still equals
+the committed on-disk product/AGENTS.md (the drift gate).
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "product" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from generator import (  # noqa: E402
+    parse_fragment,
+    render_block,
+    render_full,
+    read_repo_version,
+    strip_block_markers,
+)
+
+# The spec's strict BEGIN-marker regex (anchored to the start of a line).
+SPEC_BEGIN_RE = re.compile(r"^<!--\s*LFG:BEGIN\s+v(\S+)\s*(?:—[^>]*)?-->$")
+SPEC_END_LITERAL = "<!-- LFG:END -->"
+
+
+def _load_fragments():
+    rules_dir = ROOT / "product" / "rules"
+    return [parse_fragment(p) for p in sorted(rules_dir.glob("*.md"))]
+
+
+def test_strip_block_markers_recovers_render_full_byte_for_byte():
+    fragments = _load_fragments()
+    block = render_block(fragments)
+    assert strip_block_markers(block) == render_full(fragments)
+
+
+def test_block_begins_with_spec_regex_and_ends_with_end_marker():
+    fragments = _load_fragments()
+    block = render_block(fragments)
+    lines = block.splitlines()
+    # First line matches the spec BEGIN regex.
+    assert SPEC_BEGIN_RE.match(lines[0]), f"BEGIN line did not match spec: {lines[0]!r}"
+    # Last non-empty line is the literal END marker. render_block emits a
+    # single trailing newline after END, so the last splitlines() element is
+    # the END marker itself.
+    assert lines[-1] == SPEC_END_LITERAL
+    # And the block text ends with the END marker plus one trailing newline.
+    assert block.endswith(SPEC_END_LITERAL + "\n")
+
+
+def test_begin_marker_version_matches_version_json():
+    fragments = _load_fragments()
+    block = render_block(fragments)
+    begin_line = block.splitlines()[0]
+    captured = SPEC_BEGIN_RE.match(begin_line).group(1)
+
+    version_file = ROOT / "product" / "VERSION.json"
+    expected = json.loads(version_file.read_text(encoding="utf-8"))["version"]
+
+    assert captured == expected
+    # read_repo_version() is the same source render_block uses by default.
+    assert captured == read_repo_version()
+
+
+def test_render_full_matches_on_disk_agents_md():
+    """render_full output must equal the committed product/AGENTS.md.
+
+    This is the no-drift proof: the same content `lfg generate` writes. The
+    on-disk file is written as LF/UTF-8 with a single trailing newline by the
+    generate command, and render_full emits the same, so a plain UTF-8 read
+    compares equal with no trailing-newline fixup needed.
+    """
+    fragments = _load_fragments()
+    on_disk = (ROOT / "product" / "AGENTS.md").read_text(encoding="utf-8")
+    assert render_full(fragments) == on_disk
+
+
+def test_explicit_version_is_honored():
+    """render_block(version=...) lets callers pin a version without VERSION.json."""
+    fragments = _load_fragments()
+    block = render_block(fragments, version="9.9.9")
+    captured = SPEC_BEGIN_RE.match(block.splitlines()[0]).group(1)
+    assert captured == "9.9.9"
+    # Interior still round-trips to render_full regardless of the version token.
+    assert strip_block_markers(block) == render_full(fragments)

--- a/product/tests/test_known_template_hashes.py
+++ b/product/tests/test_known_template_hashes.py
@@ -1,0 +1,151 @@
+"""Tests for the SHA-256 template manifest (Spec 4 §3).
+
+Pins three things so the manifest can't silently rot:
+  1. The committed manifest has an entry for the current VERSION.json version.
+  2. Every file under product/templates/ at HEAD matches its recorded hash
+     (i.e. `update_template_hashes.py --check` passes).
+  3. A deliberately-wrong hash makes the check fail — proving the gate works.
+
+update_template_hashes.py is loaded via importlib from its file path
+(the .py name is fine, but match the codebase pattern for script modules).
+"""
+
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_TEMPLATES = Path(__file__).resolve().parents[1] / "templates"
+_MANIFEST = _SCRIPTS / "known_template_hashes.json"
+
+_SPEC = importlib.util.spec_from_file_location(
+    "update_template_hashes", _SCRIPTS / "update_template_hashes.py"
+)
+uth = importlib.util.module_from_spec(_SPEC)
+sys.modules["update_template_hashes"] = uth
+_SPEC.loader.exec_module(uth)
+
+
+def _current_version() -> str:
+    return uth.read_current_version()
+
+
+def test_manifest_file_exists():
+    assert _MANIFEST.exists(), "known_template_hashes.json must be committed"
+
+
+def test_manifest_has_entry_for_current_version():
+    manifest = uth.load_manifest()
+    version = _current_version()
+    assert version in manifest, f"manifest missing entry for version {version!r}"
+    assert manifest[version], "current-version entry must not be empty"
+
+
+def test_every_template_file_has_matching_hash():
+    """Every file under product/templates/ at HEAD matches the manifest."""
+    on_disk = uth.hash_templates()
+    recorded = uth.load_manifest()[_current_version()]
+
+    assert set(on_disk) == set(recorded), (
+        "template files on disk differ from the manifest's recorded set"
+    )
+    for name, digest in on_disk.items():
+        assert recorded[name] == digest, f"hash mismatch for {name}"
+
+
+def test_check_mode_passes_at_head():
+    """`--check` returns 0 when the manifest matches the working tree."""
+    assert uth.check_manifest() == 0
+
+
+def test_check_mode_fails_on_wrong_hash(monkeypatch):
+    """A deliberately-corrupted manifest makes the check fail (gate works)."""
+    version = _current_version()
+    good = uth.load_manifest()
+    tampered = {version: dict(good[version])}
+    # Flip one recorded hash to a clearly-wrong value.
+    first_key = next(iter(tampered[version]))
+    tampered[version][first_key] = "0" * 64
+
+    monkeypatch.setattr(uth, "load_manifest", lambda *a, **k: tampered)
+    assert uth.check_manifest() == 1
+
+
+def test_check_mode_fails_when_version_absent(monkeypatch):
+    """No entry for the current version is also a failure."""
+    monkeypatch.setattr(uth, "load_manifest", lambda *a, **k: {})
+    assert uth.check_manifest() == 1
+
+
+def test_hashes_are_lowercase_sha256_hex():
+    """Recorded digests are 64-char lowercase hex (defends the format)."""
+    recorded = uth.load_manifest()[_current_version()]
+    for name, digest in recorded.items():
+        assert len(digest) == 64, f"{name}: not a 64-char digest"
+        int(digest, 16)  # raises ValueError if not hex
+        assert digest == digest.lower(), f"{name}: digest must be lowercase"
+
+
+def test_manifest_keys_use_forward_slashes():
+    """Keys are POSIX-style so the manifest is identical cross-platform."""
+    recorded = uth.load_manifest()[_current_version()]
+    for name in recorded:
+        assert "\\" not in name, f"{name}: backslash in manifest key"
+
+
+# --- --match-dir mode (Spec 4 §3, T7) -------------------------------------
+
+
+def test_known_hashes_unions_all_versions():
+    """known_hashes() flattens every per-version digest into one set."""
+    manifest = {
+        "0.3.0": {"a.md": "aa", "b.md": "bb"},
+        "0.4.0": {"a.md": "cc"},
+    }
+    assert uth.known_hashes(manifest) == {"aa", "bb", "cc"}
+
+
+def test_match_dir_reports_lfg_file_and_ignores_junk(tmp_path, capsys):
+    """A dir with one real LFG template + one junk file: only the real one matches."""
+    target = tmp_path / "templates"
+    target.mkdir()
+    # Real match: copy an actual shipped template (its hash is in the manifest).
+    shutil.copy2(_TEMPLATES / "ADR_template.md", target / "ADR_template.md")
+    # Junk: not an LFG template, so its hash is absent from the manifest.
+    (target / "my_notes.md").write_text("user-authored junk\n", encoding="utf-8")
+
+    rc = uth.match_dir(target)
+    out = capsys.readouterr().out
+
+    assert rc == 0  # at least one match
+    assert "MATCH ADR_template.md" in out
+    assert "my_notes.md" not in out
+    assert "matched 1 of 2 file(s)" in out
+
+
+def test_match_dir_no_matches_is_user_authored(tmp_path, capsys):
+    """A dir of only user-authored files returns exit 1 (nothing matched)."""
+    target = tmp_path / "templates"
+    target.mkdir()
+    (target / "mine.md").write_text("entirely mine\n", encoding="utf-8")
+
+    rc = uth.match_dir(target)
+    out = capsys.readouterr().out
+
+    assert rc == 1
+    assert "MATCH" not in out
+    assert "matched 0 of 1 file(s)" in out
+
+
+def test_match_dir_missing_dir_errors(tmp_path):
+    """A non-existent directory is an error (exit 2)."""
+    assert uth.match_dir(tmp_path / "nope") == 2
+
+
+def test_match_dir_empty_dir_errors(tmp_path):
+    """An empty directory is an error (exit 2) — nothing to inspect."""
+    target = tmp_path / "templates"
+    target.mkdir()
+    assert uth.match_dir(target) == 2

--- a/product/tests/test_lfg_merge_agents_md.py
+++ b/product/tests/test_lfg_merge_agents_md.py
@@ -1,0 +1,221 @@
+"""Tests for the `lfg merge-agents-md` subcommand (Spec 4 §1 / T5).
+
+Drives the CLI via subprocess (matching test_lfg_archive.py style). Covers:
+fresh target creation, idempotent re-run, user-authored prepend (+ --no-wrap),
+and the forward-version refusal / --force-downgrade escape hatch.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LFG = ROOT / "product/scripts/lfg.py"
+
+
+def _run(args, cwd=None):
+    return subprocess.run(
+        [sys.executable, str(LFG)] + args,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def test_fresh_target_creates_file_with_markers(tmp_path):
+    target = tmp_path / "AGENTS.md"
+    r = _run(["merge-agents-md", "--to", str(target)])
+    assert r.returncode == 0, r.stderr
+    assert target.exists()
+    content = target.read_text(encoding="utf-8")
+    assert "<!-- LFG:BEGIN v" in content
+    assert "<!-- LFG:END -->" in content
+    assert "Updated" in r.stdout
+
+
+def test_run_twice_is_idempotent(tmp_path):
+    target = tmp_path / "AGENTS.md"
+    r1 = _run(["merge-agents-md", "--to", str(target)])
+    assert r1.returncode == 0, r1.stderr
+    first_bytes = target.read_bytes()
+
+    r2 = _run(["merge-agents-md", "--to", str(target)])
+    assert r2.returncode == 0, r2.stderr
+    assert "already up to date" in r2.stdout
+    # File untouched, byte-for-byte.
+    assert target.read_bytes() == first_bytes
+
+
+def test_user_authored_file_prepends_and_preserves(tmp_path):
+    target = tmp_path / "AGENTS.md"
+    user_content = (
+        "# AGENTS.md\n"
+        "\n"
+        "Hand-authored instructions for coding agents.\n"
+        "\n"
+        "## Build\n"
+        "Run `make build`.\n"
+    )
+    target.write_text(user_content, encoding="utf-8", newline="\n")
+
+    r = _run(["merge-agents-md", "--to", str(target)])
+    assert r.returncode == 0, r.stderr
+    content = target.read_text(encoding="utf-8")
+    # Block prepended at the top, user content preserved below.
+    assert content.startswith("<!-- LFG:BEGIN v")
+    assert "Hand-authored instructions for coding agents." in content
+    assert "Run `make build`." in content
+
+
+def test_no_wrap_respected_on_lfg_looking_file(tmp_path):
+    target = tmp_path / "AGENTS.md"
+    # A pre-marker LFG-looking file (frontmatter doc: AGENTS).
+    lfg_like = (
+        "---\n"
+        "doc: AGENTS\n"
+        "---\n"
+        "\n"
+        "# Old pre-marker LFG body\n"
+        "Marker-sentinel-line-to-detect.\n"
+    )
+    target.write_text(lfg_like, encoding="utf-8", newline="\n")
+
+    r = _run(["merge-agents-md", "--to", str(target), "--no-wrap"])
+    assert r.returncode == 0, r.stderr
+    content = target.read_text(encoding="utf-8")
+    # --no-wrap treats LFG-looking content as user content: block prepended,
+    # old content preserved below rather than discarded.
+    assert content.startswith("<!-- LFG:BEGIN v")
+    assert "Marker-sentinel-line-to-detect." in content
+
+
+def test_corrupt_begin_without_end_refuses_does_not_prepend(tmp_path):
+    # BLOCKER 1: a BEGIN with no END must error (non-zero) and leave the file
+    # untouched — never prepend a second BEGIN that a later merge mis-slices.
+    target = tmp_path / "AGENTS.md"
+    corrupt = (
+        "# User notes\n"
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "orphaned body, no end marker\n"
+    )
+    target.write_text(corrupt, encoding="utf-8", newline="\n")
+    before = target.read_bytes()
+
+    r = _run(["merge-agents-md", "--to", str(target)])
+    assert r.returncode != 0
+    assert "corrupt" in r.stderr.lower()
+    # File untouched, byte-for-byte — no second BEGIN injected.
+    assert target.read_bytes() == before
+
+
+def test_corrupt_begin_without_end_refuses_even_with_no_wrap(tmp_path):
+    # The corrupt-marker error fires regardless of --no-wrap.
+    target = tmp_path / "AGENTS.md"
+    corrupt = (
+        "<!-- LFG:BEGIN v0.3.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "orphaned body\n"
+    )
+    target.write_text(corrupt, encoding="utf-8", newline="\n")
+    before = target.read_bytes()
+
+    r = _run(["merge-agents-md", "--to", str(target), "--no-wrap"])
+    assert r.returncode != 0
+    assert "corrupt" in r.stderr.lower()
+    assert target.read_bytes() == before
+
+
+def test_user_authored_prepend_announces_preservation(tmp_path):
+    # SHOULD-FIX 4: prepend case prints a specific message about preservation.
+    target = tmp_path / "AGENTS.md"
+    target.write_text(
+        "# AGENTS.md\nHand-authored.\n", encoding="utf-8", newline="\n"
+    )
+    r = _run(["merge-agents-md", "--to", str(target)])
+    assert r.returncode == 0, r.stderr
+    assert "preserved" in r.stdout.lower()
+    assert "prepended" in r.stdout.lower()
+
+
+def test_newer_marker_refuses_without_force_succeeds_with(tmp_path):
+    target = tmp_path / "AGENTS.md"
+    newer = (
+        "<!-- LFG:BEGIN v99.0.0 — DO NOT EDIT BETWEEN THESE MARKERS -->\n"
+        "future body\n"
+        "<!-- LFG:END -->\n"
+    )
+    target.write_text(newer, encoding="utf-8", newline="\n")
+
+    # Without --force-downgrade: refuse, non-zero, file untouched.
+    before = target.read_bytes()
+    r1 = _run(["merge-agents-md", "--to", str(target)])
+    assert r1.returncode != 0
+    assert "force-downgrade" in r1.stderr
+    assert target.read_bytes() == before
+
+    # With --force-downgrade: succeeds, future body replaced.
+    r2 = _run(["merge-agents-md", "--to", str(target), "--force-downgrade"])
+    assert r2.returncode == 0, r2.stderr
+    content = target.read_text(encoding="utf-8")
+    assert "future body" not in content
+    assert "<!-- LFG:BEGIN v" in content
+
+
+def test_wrap_replace_backs_up_original(tmp_path):
+    """An unmarked LFG-fingerprinted AGENTS.md (e.g. v0.3.0) with user additions
+    gets its body replaced — but the original is backed up first so nothing is
+    truly lost (honors 'never lose user content')."""
+    target = tmp_path / "AGENTS.md"
+    # Minimal LFG-fingerprinted content (doc: AGENTS frontmatter) + a user note.
+    target.write_text(
+        "---\ndoc: AGENTS\n---\n\n# Log File Genius\n\nold body\n"
+        "\n<!-- my own note: KEEP-THIS-SENTINEL -->\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    r = _run(["merge-agents-md", "--to", str(target)])
+    assert r.returncode == 0, r.stderr
+    assert "Backed up" in r.stdout
+    # Result is the clean managed block; the user sentinel is gone from it...
+    result = target.read_text(encoding="utf-8")
+    assert "<!-- LFG:BEGIN v" in result
+    assert "KEEP-THIS-SENTINEL" not in result
+    # ...but preserved in the .bak.
+    backup = target.with_name("AGENTS.md.bak")
+    assert backup.exists()
+    assert "KEEP-THIS-SENTINEL" in backup.read_text(encoding="utf-8")
+
+
+def test_user_authored_prepend_makes_no_backup(tmp_path):
+    """The lossless prepend path must NOT create a backup (nothing is lost)."""
+    target = tmp_path / "AGENTS.md"
+    target.write_text("# My Agents\nCustom only, no LFG.\n", encoding="utf-8", newline="\n")
+    r = _run(["merge-agents-md", "--to", str(target)])
+    assert r.returncode == 0, r.stderr
+    assert "Backed up" not in r.stdout
+    assert not target.with_name("AGENTS.md.bak").exists()
+    assert "Custom only, no LFG." in target.read_text(encoding="utf-8")
+
+
+def test_bom_crlf_managed_file_is_renormalized(tmp_path):
+    """A managed AGENTS.md re-saved with a UTF-8 BOM + CRLF must NOT be treated
+    as up-to-date — the idempotency check compares raw bytes, so it gets a
+    normalizing rewrite to clean UTF-8/LF (encoding policy honored)."""
+    target = tmp_path / "AGENTS.md"
+    # First produce a clean managed file.
+    r1 = _run(["merge-agents-md", "--to", str(target)])
+    assert r1.returncode == 0, r1.stderr
+    clean = target.read_bytes()
+
+    # Re-save it with a UTF-8 BOM and CRLF line endings (Notepad-style).
+    target.write_bytes(b"\xef\xbb\xbf" + clean.replace(b"\n", b"\r\n"))
+    assert target.read_bytes()[:3] == b"\xef\xbb\xbf"
+    assert b"\r\n" in target.read_bytes()
+
+    # Re-run: must rewrite (not "already up to date") and normalize the bytes.
+    r2 = _run(["merge-agents-md", "--to", str(target)])
+    assert r2.returncode == 0, r2.stderr
+    assert "already up to date" not in r2.stdout
+    after = target.read_bytes()
+    assert after[:3] != b"\xef\xbb\xbf"  # BOM gone
+    assert b"\r\n" not in after  # CRLF gone
+    assert after == clean  # back to canonical bytes

--- a/product/tests/test_lfg_migrate_state.py
+++ b/product/tests/test_lfg_migrate_state.py
@@ -1,0 +1,183 @@
+"""CLI-level tests for `lfg migrate-state` (Spec 4 §2, T10).
+
+Mirrors test_lfg_archive.py: drive the real lfg.py via subprocess against
+temp STATE/DEVLOG fixtures. The pure plan/apply logic lives in
+test_migrate_state.py; here we pin the CLI surface:
+  - --dry-run prints a plan and writes NOTHING.
+  - --force applies without a prompt (STATE rewritten, DEVLOG snapshot appended).
+  - already-compliant + empty-plan STATE -> nothing-to-do, exit 0, files unchanged.
+  - already-migrated (DEVLOG has snapshot) -> already-migrated, exit 0, unchanged.
+"""
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LFG = ROOT / "product/scripts/lfg.py"
+
+
+def _run(args, cwd, stdin=""):
+    return subprocess.run(
+        [sys.executable, str(LFG)] + args,
+        cwd=str(cwd), input=stdin, capture_output=True, text=True, encoding="utf-8",
+    )
+
+
+def _seed_config(tmp_path):
+    (tmp_path / ".logfile-config.yml").write_text(textwrap.dedent("""
+        paths:
+          changelog: logs/CHANGELOG.md
+          devlog: logs/DEVLOG.md
+          state: logs/STATE.md
+        token_targets:
+          state: 500
+    """), encoding="utf-8")
+    (tmp_path / "logs").mkdir(exist_ok=True)
+
+
+# A v0.2-style STATE: canonical Current Context (so it passes the structural
+# validator) PLUS non-canonical sections carrying real content + an empty
+# placeholder. The non-canonical real content makes build_plan non-empty.
+_BROWNFIELD_STATE = textwrap.dedent("""\
+    # Current State
+
+    ## Current Context
+
+    Working on the brownfield migration helper.
+
+    ## Last Session
+
+    Wired the CLI subcommand.
+
+    ## Open Questions
+
+    - Should we archive the old roadmap notes?
+    - How do we handle multi-repo state?
+
+    ## Legacy Roadmap
+
+    Phase 1: ship the parser. Phase 2: ship apply. Phase 3: dogfood.
+
+    ## Empty Placeholder
+
+    *None*
+""")
+
+_DEVLOG = textwrap.dedent("""\
+    # Development Log
+
+    ## Daily Log
+
+    ### 2026-05-30: Initial work
+    - Started the migration module.
+""")
+
+
+def _seed_brownfield(tmp_path):
+    _seed_config(tmp_path)
+    (tmp_path / "logs" / "STATE.md").write_text(_BROWNFIELD_STATE, encoding="utf-8")
+    (tmp_path / "logs" / "DEVLOG.md").write_text(_DEVLOG, encoding="utf-8")
+
+
+def test_migrate_state_dry_run_writes_nothing(tmp_path):
+    _seed_brownfield(tmp_path)
+    state = tmp_path / "logs" / "STATE.md"
+    devlog = tmp_path / "logs" / "DEVLOG.md"
+    state_before = state.read_bytes()
+    devlog_before = devlog.read_bytes()
+
+    r = _run(["migrate-state", "--dry-run"], cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "STATE migration plan" in r.stdout
+    # Non-canonical real content shows up in the plan.
+    assert "ARCHIVE TO DEVLOG" in r.stdout
+
+    # Byte-identical: dry-run wrote nothing.
+    assert state.read_bytes() == state_before
+    assert devlog.read_bytes() == devlog_before
+
+
+def test_migrate_state_force_applies_without_prompt(tmp_path):
+    _seed_brownfield(tmp_path)
+    state = tmp_path / "logs" / "STATE.md"
+    devlog = tmp_path / "logs" / "DEVLOG.md"
+    state_before = state.read_text(encoding="utf-8")
+    devlog_before = devlog.read_text(encoding="utf-8")
+
+    r = _run(["migrate-state", "--force"], cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "Applied STATE migration" in r.stdout
+
+    state_after = state.read_text(encoding="utf-8")
+    devlog_after = devlog.read_text(encoding="utf-8")
+
+    # STATE rewritten: non-canonical sections removed; canonical kept.
+    assert state_after != state_before
+    assert "## Current Context" in state_after
+    assert "## Legacy Roadmap" not in state_after
+    assert "## Open Questions" not in state_after
+
+    # DEVLOG got the one-shot snapshot entry with the archived content.
+    assert devlog_after != devlog_before
+    assert "STATE snapshot pre-v0.4.0 migration" in devlog_after
+    assert "Legacy Roadmap" in devlog_after
+
+
+def test_migrate_state_compliant_empty_plan_is_noop(tmp_path):
+    """STATE already conforms (only canonical sections) -> nothing to do, exit 0."""
+    _seed_config(tmp_path)
+    compliant = textwrap.dedent("""\
+        # Current State
+
+        ## Current Context
+
+        All good here.
+
+        ## Last Session
+
+        Nothing pending.
+    """)
+    state = tmp_path / "logs" / "STATE.md"
+    state.write_text(compliant, encoding="utf-8")
+    (tmp_path / "logs" / "DEVLOG.md").write_text(_DEVLOG, encoding="utf-8")
+
+    state_before = state.read_bytes()
+    devlog_before = (tmp_path / "logs" / "DEVLOG.md").read_bytes()
+
+    r = _run(["migrate-state", "--force"], cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "nothing to migrate" in r.stdout.lower()
+
+    assert state.read_bytes() == state_before
+    assert (tmp_path / "logs" / "DEVLOG.md").read_bytes() == devlog_before
+
+
+def test_migrate_state_already_migrated_is_noop(tmp_path):
+    """DEVLOG already carries the snapshot entry -> guard 2 trips, exit 0, unchanged."""
+    _seed_config(tmp_path)
+    state = tmp_path / "logs" / "STATE.md"
+    state.write_text(_BROWNFIELD_STATE, encoding="utf-8")
+    devlog = tmp_path / "logs" / "DEVLOG.md"
+    devlog.write_text(textwrap.dedent("""\
+        # Development Log
+
+        ## Daily Log
+
+        ### 2026-05-31: Recent work
+        - Did stuff.
+
+        ### 2026-05-30: STATE snapshot pre-v0.4.0 migration
+
+        (previously migrated)
+    """), encoding="utf-8")
+
+    state_before = state.read_bytes()
+    devlog_before = devlog.read_bytes()
+
+    r = _run(["migrate-state", "--force"], cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "already" in r.stdout.lower()
+
+    assert state.read_bytes() == state_before
+    assert devlog.read_bytes() == devlog_before

--- a/product/tests/test_lfg_validate_scope.py
+++ b/product/tests/test_lfg_validate_scope.py
@@ -1,0 +1,64 @@
+"""Regression test: `lfg validate --changelog` / `--devlog` must forward the
+flags lint-logs.py actually accepts (--changelog / --devlog), not the
+nonexistent --changelog-only / --devlog-only variants.
+
+Before the fix, cmd_validate appended '--changelog-only'/'--devlog-only', so
+argparse in lint-logs.py died with "unrecognized arguments". These tests assert
+both subcommands exit cleanly and scope validation to the single named file.
+"""
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LFG = ROOT / "product/scripts/lfg.py"
+
+
+def _run(args, cwd, stdin=""):
+    return subprocess.run(
+        [sys.executable, str(LFG)] + args,
+        cwd=str(cwd), input=stdin, capture_output=True, text=True, encoding="utf-8",
+    )
+
+
+def _seed_clean_logs(tmp_path):
+    (tmp_path / ".logfile-config.yml").write_text(textwrap.dedent("""
+        paths:
+          changelog: logs/CHANGELOG.md
+          devlog: logs/DEVLOG.md
+        token_targets:
+          changelog: 100000
+          devlog: 100000
+          combined: 200000
+    """), encoding="utf-8")
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "See https://keepachangelog.com/ for format.\n\n"
+        "## [Unreleased]\n- nothing yet\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "logs" / "DEVLOG.md").write_text(
+        "# Development Log\n\n## Daily Log\n\n### 2026-05-28: x\n- y\n",
+        encoding="utf-8",
+    )
+
+
+def test_validate_changelog_only(tmp_path):
+    _seed_clean_logs(tmp_path)
+    r = _run(["validate", "--changelog", "--json"], cwd=tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+    results = json.loads(r.stdout)["results"]
+    assert len(results) == 1, results
+    assert "CHANGELOG" in results[0]["file"]
+
+
+def test_validate_devlog_only(tmp_path):
+    _seed_clean_logs(tmp_path)
+    r = _run(["validate", "--devlog", "--json"], cwd=tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+    results = json.loads(r.stdout)["results"]
+    assert len(results) == 1, results
+    assert "DEVLOG" in results[0]["file"]

--- a/product/tests/test_migrate_state.py
+++ b/product/tests/test_migrate_state.py
@@ -1,0 +1,395 @@
+"""Tests for migrate_state.py — brownfield STATE.md migration (Spec 4 §2).
+
+Mirrors test_archive.py's structure: parser tests, plan-builder tests, then
+apply() behavior including the two idempotency guards and atomic two-file write.
+"""
+import importlib.util
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from migrate_state import (
+    parse_state, split_preamble, build_plan, apply,
+    MigratePlan, Section, MigrateError,
+    CANONICAL_SECTIONS, SNAPSHOT_HEADING_RE, SNAPSHOT_TITLE,
+    _estimate_tokens, DEFAULT_STATE_TARGET,
+)
+
+TODAY = "2026-06-01"
+
+
+# --- helpers ----------------------------------------------------------------
+
+def _config(state_target: int = 500) -> dict:
+    return {"token_targets": {"state": state_target}}
+
+
+# A non-compliant STATE.md: missing `## Current Context` would be the structural
+# error, but here we keep Current Context and add a non-canonical section so the
+# plan has work to do; non-compliance for Guard 1 is driven by token budget in
+# some tests and by missing Current Context in others.
+NONCANONICAL_STATE = textwrap.dedent("""\
+    ---
+    doc: STATE
+    ---
+
+    # Current State
+
+    ## Current Context
+
+    - **Project:** Demo
+    - **Version:** v0.2.0
+
+    ## Last Session
+
+    - **Done:** shipped a thing
+
+    ## Old Sprint Notes
+
+    - We decided to use Postgres because of RLS.
+    - Migrated the billing table on 2026-04-02.
+
+    ## Empty Placeholder
+
+    - *None*
+    """)
+
+
+def _devlog(extra: str = "") -> str:
+    return textwrap.dedent("""\
+        ---
+        doc: DEVLOG
+        ---
+
+        # Development Log
+
+        ## Daily Log - Newest First
+
+        ### 2026-05-30: Today's work
+
+        Implemented the migrate verb.
+
+        ### 2026-05-01: Earlier work
+
+        Set up the repo.
+        """) + extra
+
+
+def _write_project(tmp_path, state_text, devlog_text, state_target=500):
+    (tmp_path / ".logfile-config.yml").write_text(
+        "paths:\n  state: logs/STATE.md\n  devlog: logs/DEVLOG.md\n"
+        f"token_targets:\n  state: {state_target}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "logs").mkdir(exist_ok=True)
+    (tmp_path / "logs" / "STATE.md").write_text(state_text, encoding="utf-8")
+    (tmp_path / "logs" / "DEVLOG.md").write_text(devlog_text, encoding="utf-8")
+    return tmp_path / "logs" / "STATE.md", tmp_path / "logs" / "DEVLOG.md"
+
+
+# --- parse_state ------------------------------------------------------------
+
+def test_estimate_tokens_is_chars_div_4():
+    assert _estimate_tokens("") == 0
+    assert _estimate_tokens("a" * 100) == 25
+
+
+def test_parse_state_splits_sections_and_counts_tokens():
+    sections = parse_state(NONCANONICAL_STATE)
+    headings = [s.heading for s in sections]
+    assert headings == [
+        "Current Context", "Last Session", "Old Sprint Notes", "Empty Placeholder",
+    ]
+    for s in sections:
+        assert s.tokens == _estimate_tokens(s.raw)
+        assert s.tokens > 0
+
+
+def test_split_preamble_separates_frontmatter():
+    preamble, sections = split_preamble(NONCANONICAL_STATE)
+    assert "doc: STATE" in preamble
+    assert "# Current State" in preamble
+    assert sections[0].heading == "Current Context"
+
+
+def test_parse_state_no_headings_returns_empty():
+    assert parse_state("just frontmatter\nno headings\n") == []
+
+
+def test_section_matches_canonical_with_suffix():
+    s = Section(heading="Current Context (Source of Truth)", raw="", tokens=0)
+    assert s.matches_canonical() == "Current Context"
+
+
+# --- build_plan -------------------------------------------------------------
+
+def test_build_plan_keeps_canonical_archives_user_drops_empty():
+    plan = build_plan(NONCANONICAL_STATE, _config())
+    keep_headings = [s.heading for s in plan.keep]
+    assert "Current Context" in keep_headings
+    assert "Last Session" in keep_headings
+
+    archived = [s.heading for s in plan.archive_to_devlog]
+    assert "Old Sprint Notes" in archived  # real content
+
+    dropped = [s.heading for s in plan.drop]
+    assert "Empty Placeholder" in dropped  # *None* placeholder
+
+
+def test_build_plan_target_from_config():
+    plan = build_plan(NONCANONICAL_STATE, _config(state_target=750))
+    assert plan.target_tokens == 750
+    plan_default = build_plan(NONCANONICAL_STATE, {})
+    assert plan_default.target_tokens == DEFAULT_STATE_TARGET
+
+
+def test_build_plan_keeps_canonical_order():
+    # Even though "Last Session" appears before "Current Context" in the source,
+    # keep order follows CANONICAL_SECTIONS.
+    text = textwrap.dedent("""\
+        # State
+        ## Last Session
+        - done
+
+        ## Current Context
+        - **Project:** X
+        """)
+    plan = build_plan(text, _config())
+    headings = [s.heading for s in plan.keep]
+    assert headings.index("Current Context") < headings.index("Last Session")
+
+
+def test_build_plan_truncates_over_budget_kept_section():
+    # A Current Context section far over the 500-token budget must be truncated
+    # and flagged, keeping the most-recent (trailing) lines.
+    big_lines = "\n".join(f"- old line {i}" for i in range(400))
+    recent = "- NEWEST: this must survive truncation"
+    text = f"# State\n## Current Context\n{big_lines}\n{recent}\n"
+    plan = build_plan(text, _config(state_target=100))
+    kept = next(s for s in plan.keep if s.heading == "Current Context")
+    assert kept.tokens <= 100
+    assert "NEWEST" in kept.raw           # most-recent content survives
+    assert "truncated" in kept.raw.lower()
+    assert plan.truncations               # truncation recorded
+    assert any("Current Context" in note for note in plan.truncations)
+
+
+def test_build_plan_structural_section_kept():
+    text = textwrap.dedent("""\
+        # State
+        ## Related Documents
+        [CHANGELOG](./CHANGELOG.md)
+
+        ## Current Context
+        - **Project:** X
+        """)
+    plan = build_plan(text, _config())
+    assert "Related Documents" in [s.heading for s in plan.keep]
+    assert not plan.archive_to_devlog
+
+
+# --- apply: success path ----------------------------------------------------
+
+def test_apply_writes_state_and_appends_snapshot_at_end_of_daily_log(tmp_path):
+    state_path, devlog_path = _write_project(tmp_path, NONCANONICAL_STATE, _devlog())
+    plan = build_plan(NONCANONICAL_STATE, _config())
+
+    apply(plan, state_path, devlog_path, today=TODAY,
+          config_path=tmp_path / ".logfile-config.yml")
+
+    new_state = state_path.read_text(encoding="utf-8")
+    # Canonical kept; non-canonical archived out of STATE; placeholder dropped.
+    assert "## Current Context" in new_state
+    assert "## Last Session" in new_state
+    assert "Old Sprint Notes" not in new_state
+    assert "Empty Placeholder" not in new_state
+
+    new_devlog = read_devlog = devlog_path.read_text(encoding="utf-8")
+    # Snapshot heading present, exact form.
+    assert SNAPSHOT_HEADING_RE.search(new_devlog)
+    assert f"### {TODAY}: {SNAPSHOT_TITLE}" in new_devlog
+    # Archived section content moved into the snapshot.
+    assert "Old Sprint Notes" in new_devlog
+    assert "Postgres because of RLS" in new_devlog
+
+    # Position: snapshot is at the END of Daily Log — after the oldest existing
+    # entry (2026-05-01) and before any later `## ` section. Assert it comes
+    # AFTER the oldest dated entry's body, not at the top.
+    idx_snapshot = new_devlog.index(SNAPSHOT_TITLE)
+    idx_oldest = new_devlog.index("2026-05-01")
+    idx_newest = new_devlog.index("2026-05-30")
+    assert idx_newest < idx_oldest < idx_snapshot
+
+
+def test_apply_snapshot_before_archive_section(tmp_path):
+    devlog = _devlog(extra="\n## Archive\n\n- [old.md](archive/old.md) — older\n")
+    state_path, devlog_path = _write_project(tmp_path, NONCANONICAL_STATE, devlog)
+    plan = build_plan(NONCANONICAL_STATE, _config())
+    apply(plan, state_path, devlog_path, today=TODAY,
+          config_path=tmp_path / ".logfile-config.yml")
+    out = devlog_path.read_text(encoding="utf-8")
+    # Snapshot sits inside Daily Log, i.e. before the `## Archive` heading.
+    assert out.index(SNAPSHOT_TITLE) < out.index("## Archive")
+
+
+def test_apply_state_only_when_nothing_to_archive(tmp_path):
+    # No non-canonical content -> only truncation/drop work; DEVLOG untouched.
+    text = textwrap.dedent("""\
+        # State
+        ## Current Context
+        - **Project:** X
+        ## Empty
+        - *None*
+        """)
+    state_path, devlog_path = _write_project(tmp_path, text, _devlog())
+    devlog_before = devlog_path.read_text(encoding="utf-8")
+    plan = build_plan(text, _config())
+    assert not plan.archive_to_devlog
+    apply(plan, state_path, devlog_path, today=TODAY,
+          config_path=tmp_path / ".logfile-config.yml")
+    assert "## Empty" not in state_path.read_text(encoding="utf-8")
+    # DEVLOG unchanged (no snapshot needed).
+    assert devlog_path.read_text(encoding="utf-8") == devlog_before
+
+
+# --- apply: guards ----------------------------------------------------------
+
+def test_guard1_compliant_state_refuses(tmp_path):
+    compliant = textwrap.dedent("""\
+        ---
+        doc: STATE
+        ---
+        # Current State
+        ## Current Context
+        - **Project:** X
+        ## Last Session
+        - **Done:** y
+        """)
+    state_path, devlog_path = _write_project(tmp_path, compliant, _devlog())
+    plan = build_plan(compliant, _config())
+    with pytest.raises(MigrateError, match="already passes"):
+        apply(plan, state_path, devlog_path, today=TODAY,
+              config_path=tmp_path / ".logfile-config.yml")
+
+
+def test_guard2_existing_snapshot_refuses(tmp_path):
+    devlog = _devlog(
+        extra=f"\n### {TODAY}: {SNAPSHOT_TITLE}\n\nalready migrated once\n"
+    )
+    state_path, devlog_path = _write_project(tmp_path, NONCANONICAL_STATE, devlog)
+    plan = build_plan(NONCANONICAL_STATE, _config())
+    with pytest.raises(MigrateError, match="already contains"):
+        apply(plan, state_path, devlog_path, today=TODAY,
+              config_path=tmp_path / ".logfile-config.yml")
+
+
+def test_idempotency_second_apply_refuses(tmp_path):
+    state_path, devlog_path = _write_project(tmp_path, NONCANONICAL_STATE, _devlog())
+    cfg = tmp_path / ".logfile-config.yml"
+    plan = build_plan(NONCANONICAL_STATE, _config())
+    apply(plan, state_path, devlog_path, today=TODAY, config_path=cfg)
+
+    # Second run: STATE is now compliant (Guard 1) AND DEVLOG has the snapshot
+    # (Guard 2). Either alone refuses; here both should.
+    plan2 = build_plan(state_path.read_text(encoding="utf-8"), _config())
+    with pytest.raises(MigrateError):
+        apply(plan2, state_path, devlog_path, today=TODAY, config_path=cfg)
+
+
+def test_idempotency_guard2_after_state_edited_back(tmp_path):
+    # Migrate, then edit STATE back into non-compliance; Guard 2 still refuses.
+    state_path, devlog_path = _write_project(tmp_path, NONCANONICAL_STATE, _devlog())
+    cfg = tmp_path / ".logfile-config.yml"
+    apply(build_plan(NONCANONICAL_STATE, _config()), state_path, devlog_path,
+          today=TODAY, config_path=cfg)
+    # User re-breaks STATE (removes Current Context -> structural error).
+    state_path.write_text("# State\n## Random\n- stuff\n", encoding="utf-8")
+    plan2 = build_plan(state_path.read_text(encoding="utf-8"), _config())
+    with pytest.raises(MigrateError, match="already contains"):
+        apply(plan2, state_path, devlog_path, today=TODAY, config_path=cfg)
+
+
+# --- DEVLOG validator round-trip --------------------------------------------
+
+def test_snapshot_devlog_round_trips_through_validator(tmp_path):
+    state_path, devlog_path = _write_project(tmp_path, NONCANONICAL_STATE, _devlog())
+    cfg = tmp_path / ".logfile-config.yml"
+    apply(build_plan(NONCANONICAL_STATE, _config()), state_path, devlog_path,
+          today=TODAY, config_path=cfg)
+
+    # Load lint-logs and validate the migrated DEVLOG — no new errors.
+    spec = importlib.util.spec_from_file_location(
+        "lint_logs", Path(__file__).resolve().parents[1] / "scripts" / "lint-logs.py"
+    )
+    lint_logs = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(lint_logs)
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        linter = lint_logs.LogLinter(config_path=str(cfg))
+        result = linter.validate_devlog()
+    finally:
+        os.chdir(cwd)
+    assert result.errors == 0
+
+
+# --- atomicity --------------------------------------------------------------
+
+def test_atomicity_devlog_write_failure_leaves_state_unmigrated(tmp_path, monkeypatch):
+    state_path, devlog_path = _write_project(tmp_path, NONCANONICAL_STATE, _devlog())
+    cfg = tmp_path / ".logfile-config.yml"
+    state_before = state_path.read_text(encoding="utf-8")
+    devlog_before = devlog_path.read_text(encoding="utf-8")
+
+    plan = build_plan(NONCANONICAL_STATE, _config())
+
+    import migrate_state
+    real_replace = os.replace
+
+    def failing_replace(src, dst):
+        # Fail the DEVLOG commit (first os.replace). STATE must not land.
+        if str(dst) == str(devlog_path):
+            raise OSError("simulated DEVLOG replace failure")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(migrate_state.os, "replace", failing_replace)
+
+    with pytest.raises(OSError, match="simulated DEVLOG"):
+        apply(plan, state_path, devlog_path, today=TODAY, config_path=cfg)
+
+    # Neither file changed; no stray tmp files.
+    assert state_path.read_text(encoding="utf-8") == state_before
+    assert devlog_path.read_text(encoding="utf-8") == devlog_before
+    assert not (state_path.with_name(state_path.name + ".lfg-tmp")).exists()
+    assert not (devlog_path.with_name(devlog_path.name + ".lfg-tmp")).exists()
+
+
+def test_atomicity_state_write_failure_after_devlog_keeps_snapshot(tmp_path, monkeypatch):
+    # If the STATE replace fails AFTER DEVLOG committed, the snapshot is kept
+    # (lossless) and STATE retains its original content; Guard 2 blocks re-run.
+    state_path, devlog_path = _write_project(tmp_path, NONCANONICAL_STATE, _devlog())
+    cfg = tmp_path / ".logfile-config.yml"
+    state_before = state_path.read_text(encoding="utf-8")
+    plan = build_plan(NONCANONICAL_STATE, _config())
+
+    import migrate_state
+    real_replace = os.replace
+
+    def failing_replace(src, dst):
+        if str(dst) == str(state_path):
+            raise OSError("simulated STATE replace failure")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(migrate_state.os, "replace", failing_replace)
+    with pytest.raises(OSError, match="simulated STATE"):
+        apply(plan, state_path, devlog_path, today=TODAY, config_path=cfg)
+
+    # STATE unchanged; DEVLOG has the snapshot (lossless).
+    assert state_path.read_text(encoding="utf-8") == state_before
+    assert SNAPSHOT_HEADING_RE.search(devlog_path.read_text(encoding="utf-8"))
+    # No stray STATE tmp.
+    assert not (state_path.with_name(state_path.name + ".lfg-tmp")).exists()

--- a/product/tests/test_validate_state_only.py
+++ b/product/tests/test_validate_state_only.py
@@ -1,0 +1,104 @@
+"""Tests for `lfg validate --state-only` (Spec 4, T8).
+
+The state-only mode lets callers (e.g. update.{sh,ps1}) detect a
+STATE-specific validation failure without false-positiving on unrelated
+CHANGELOG/DEVLOG issues. It exits non-zero (2) iff STATE.md has ERRORS;
+budget warnings stay exit 0 (matching lint-logs' errors-only convention).
+"""
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LFG = ROOT / "product/scripts/lfg.py"
+
+# A STATE.md is "clean" when it has the v0.3.0 `## Current Context` section
+# and is within budget.
+CLEAN_STATE = "# Current State\n\n## Current Context\n\n- Version: v1\n"
+# Missing `## Current Context` is the STATE validation ERROR.
+BROKEN_STATE = "# Current State\n\n## Some Other Heading\n\n- nothing useful\n"
+
+
+def _run(args, cwd, stdin=""):
+    return subprocess.run(
+        [sys.executable, str(LFG)] + args,
+        cwd=str(cwd), input=stdin, capture_output=True, text=True, encoding="utf-8",
+    )
+
+
+def _write_config(tmp_path):
+    (tmp_path / ".logfile-config.yml").write_text(textwrap.dedent("""
+        paths:
+          changelog: logs/CHANGELOG.md
+          devlog: logs/DEVLOG.md
+          state: logs/STATE.md
+        token_targets:
+          changelog: 10000
+          devlog: 15000
+          combined: 25000
+          state: 500
+    """), encoding="utf-8")
+    (tmp_path / "logs").mkdir()
+
+
+def _write_clean_changelog_devlog(tmp_path):
+    (tmp_path / "logs" / "CHANGELOG.md").write_text(
+        "# Changelog\n\nhttps://keepachangelog.com/\n\n## [Unreleased]\n"
+        "- Added thing. Files: `src/a.py`. Commit: `abc1234`\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "logs" / "DEVLOG.md").write_text(
+        "# Development Log\n\n## Daily Log\n\n### 2026-05-28: x\n- y\n", encoding="utf-8")
+
+
+def test_state_only_broken_state_exits_nonzero(tmp_path):
+    """STATE.md with a known error (no Current Context) -> exit 2."""
+    _write_config(tmp_path)
+    _write_clean_changelog_devlog(tmp_path)
+    (tmp_path / "logs" / "STATE.md").write_text(BROKEN_STATE, encoding="utf-8")
+    r = _run(["validate", "--state-only"], cwd=tmp_path)
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert "Current Context" in r.stdout
+
+
+def test_state_only_clean_state_exits_zero(tmp_path):
+    """A clean STATE.md -> exit 0."""
+    _write_config(tmp_path)
+    _write_clean_changelog_devlog(tmp_path)
+    (tmp_path / "logs" / "STATE.md").write_text(CLEAN_STATE, encoding="utf-8")
+    r = _run(["validate", "--state-only"], cwd=tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_state_only_ignores_broken_changelog(tmp_path):
+    """Broken CHANGELOG + clean STATE -> state-only still exits 0.
+
+    This is the whole point: the advisory must not fire on unrelated
+    CHANGELOG/DEVLOG problems.
+    """
+    _write_config(tmp_path)
+    # Broken CHANGELOG: missing the required ## [Unreleased] section (an ERROR
+    # in full validation). Empty DEVLOG (missing Daily Log -> warning).
+    (tmp_path / "logs" / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [0.1.0] - 2026-01-01\n- no unreleased section\n", encoding="utf-8")
+    (tmp_path / "logs" / "DEVLOG.md").write_text("# Development Log\n", encoding="utf-8")
+    (tmp_path / "logs" / "STATE.md").write_text(CLEAN_STATE, encoding="utf-8")
+
+    # Sanity: the full run DOES fail (proves the CHANGELOG is genuinely broken).
+    full = _run(["validate"], cwd=tmp_path)
+    assert full.returncode == 2, full.stdout + full.stderr
+
+    # State-only ignores the CHANGELOG error.
+    r = _run(["validate", "--state-only"], cwd=tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_full_validate_unchanged_when_state_broken(tmp_path):
+    """The existing full `lfg validate` still surfaces a broken STATE as an error."""
+    _write_config(tmp_path)
+    _write_clean_changelog_devlog(tmp_path)
+    (tmp_path / "logs" / "STATE.md").write_text(BROKEN_STATE, encoding="utf-8")
+    r = _run(["validate"], cwd=tmp_path)
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert "Current Context" in r.stdout


### PR DESCRIPTION
## Summary

Makes install/update **safe on existing projects** — triggered by a real v0.2→v0.3 migration (FFAI) that surfaced 5 defects, the worst being silent loss of a user's `AGENTS.md`.

## Managed-block AGENTS.md (P0 — never lose user content)
- install/update **merge** a marker-delimited block (`<!-- LFG:BEGIN v… -->` … `<!-- LFG:END -->`) instead of overwriting.
- User-authored `AGENTS.md` → block prepended, content preserved. Prior LFG `AGENTS.md` (v0.3.0, no markers) → regenerated with the original saved to `.bak` first.
- New `lfg merge-agents-md --to <path> [--no-wrap] [--force-downgrade]`. ForwardVersionError refuses a newer-versioned block; CorruptMarkerError refuses a half-broken one. Atomic UTF-8/LF/no-BOM writes.

## Brownfield STATE migration
- New `lfg migrate-state [--dry-run] [--force]` — keeps canonical sections, archives the rest into a one-time DEVLOG snapshot, two idempotency guards (one-shot).
- `update.{sh,ps1}` print a non-interactive advisory via `lfg validate --state-only`.

## Templates
- Stop copying templates to project root. Updater backs up an LFG-installed root `templates/` to `.log-file-genius/.backups/` via SHA-256 manifest.

## Fixes
- Backwards version-check + stale hardcoded latest version.
- Checksum self-check normalizes BOM/line-endings (was unpassable cross-platform).
- `lfg validate --changelog/--devlog` forward the flags lint-logs accepts.

## Test plan
- [x] pytest — 188 passed (108 new)
- [x] lfg generate --check — no drift
- [x] check-version — passes cross-platform
- [x] bash + PowerShell smoke (install + update) — green
- [x] Dogfooded brownfield v0.3.0→HEAD + this-repo
- [x] code-owl ×3 + dogfood

Bumped to v0.4.0.

Generated with Claude Code