### PR TITLE
fix(template): bump config template to 0.4.0 and correct doc paths

### DIFF
--- a/product/scripts/known_template_hashes.json
+++ b/product/scripts/known_template_hashes.json
@@ -9,7 +9,7 @@
     "STATE_template.md": "b08fe7638bc5c02de304870f1e915b110f0f4f5d70ddf5b09101ae6a1cc396f0"
   },
   "0.4.0": {
-    ".logfile-config.yml": "90a4f61a82ba6b3be7ac16cab3844f78a79593e38e26233b7917d7c64e2fe38b",
+    ".logfile-config.yml": "b7b2cf7d2c8a6601144ffbeec8534b69443b4c200c03915ac73199dc7a9b9ccf",
     "ADR_template.md": "6893acdeb7fed0f35ae080813274fbe604a3a80648053b033e49245bbeb4ed1d",
     "CHANGELOG_template.md": "c11a02bf21b0b2b4b472acbad9951cb5e7f2c7040b97f29d1b9bc84ee6f8241a",
     "DEVLOG_template.md": "1a33af384fe15d216277ce0e229502f48494f692baff79019bf1db4d3cf55d78",

--- a/product/templates/.logfile-config.yml
+++ b/product/templates/.logfile-config.yml
@@ -6,7 +6,7 @@
 # ============================================================================
 # Log File Genius version (used for update notifications)
 # Check for updates: https://github.com/clark-mackey/log-file-genius/releases
-log_file_genius_version: "0.2.0"
+log_file_genius_version: "0.4.0"
 
 # ============================================================================
 # PROFILE SELECTION
@@ -18,8 +18,8 @@ log_file_genius_version: "0.2.0"
 # - open-source: Public projects (strict formatting, community-facing docs)
 # - startup: Fast-moving startups/MVPs (minimal overhead, maximum speed)
 #
-# See .log-file-genius/profiles/*.yml for full profile definitions
-# See .log-file-genius/docs/profile-selection-guide.md for help choosing
+# See .log-file-genius/product/profiles/*.yml for full profile definitions
+# See .log-file-genius/product/docs/profile-selection-guide.md for help choosing
 # ============================================================================
 
 profile: solo-developer
@@ -134,10 +134,10 @@ profile: solo-developer
 # DOCUMENTATION
 # ============================================================================
 # For more information:
-# - Profile definitions: .log-file-genius/profiles/*.yml
-# - Profile selection guide: .log-file-genius/docs/profile-selection-guide.md
-# - Schema documentation: .log-file-genius/docs/profile-schema.md
-# - Validation guide: .log-file-genius/docs/validation-guide.md
-# - Log file how-to: .log-file-genius/docs/log_file_how_to.md
+# - Profile definitions: .log-file-genius/product/profiles/*.yml
+# - Profile selection guide: .log-file-genius/product/docs/profile-selection-guide.md
+# - Schema documentation: .log-file-genius/product/docs/profile-schema.md
+# - Validation guide: .log-file-genius/product/docs/validation-guide.md
+# - Log file how-to: .log-file-genius/product/docs/log_file_how_to.md
 # ============================================================================
 

--- a/product/tests/test_config_parser.py
+++ b/product/tests/test_config_parser.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 import pytest
 from pathlib import Path
@@ -56,10 +57,14 @@ def test_template_config_parses():
     # profiles/*.yml files are documentation using YAML features (block scalars,
     # lists, deep nesting) deliberately outside this parser's subset, so they are
     # NOT parsed at runtime and are not exercised here.
-    template = Path(__file__).resolve().parents[1] / "templates" / ".logfile-config.yml"
+    product_root = Path(__file__).resolve().parents[1]
+    template = product_root / "templates" / ".logfile-config.yml"
     cfg = parse_config(str(template))
     assert cfg["profile"] == "solo-developer"
-    assert cfg["log_file_genius_version"] == "0.2.0"
+    # The template must ship the current release version, or manual-copy
+    # installs report a phantom pending update forever (issue #9).
+    released = json.loads((product_root / "VERSION.json").read_text())["version"]
+    assert cfg["log_file_genius_version"] == released
 
 
 def test_bom_prefixed_config_parses_first_key(tmp_path):


### PR DESCRIPTION
## Summary

Fixes two downstream-reported bugs in the shipped config template (`product/templates/.logfile-config.yml`):

- **#9** — template hardcoded `log_file_genius_version: "0.2.0"`, never bumped for 0.3.0/0.4.0. Manual-copy installs (the template header itself says "copy this file") reported a phantom pending update forever via `check-for-updates`. Now `0.4.0`.
- **#10** — six doc-path comments pointed at `.log-file-genius/docs/` and `.log-file-genius/profiles/`, which don't exist in an installed project. Corrected to the submodule layout: `.log-file-genius/product/docs/` and `.log-file-genius/product/profiles/`.

## Drift prevention

`test_template_config_parses` previously pinned the version to a hardcoded `"0.2.0"` — the same staleness trap as the template. It now asserts against `product/VERSION.json`, so any future release bump that misses the template fails CI.

## Also

- Regenerated `known_template_hashes.json` (template content changed; `update_template_hashes.py --check` must pass).

## Testing

`python -m pytest product/tests/` — 187 passed, 1 skipped.

Fixes #9, fixes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)